### PR TITLE
Update to new verilog filelist parser crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "sv-parser 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "verilog-filelist-parser 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -710,6 +711,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "verilog-filelist-parser"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "version_check"
@@ -840,6 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum verilog-filelist-parser 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41592b8f942197470eff145ad2e5fd2aa244b6939600f3a86b8ef0636f5e48d9"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
  "sv-parser 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "verilog-filelist-parser 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "verilog-filelist-parser 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -714,7 +714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "verilog-filelist-parser"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -849,7 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum verilog-filelist-parser 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41592b8f942197470eff145ad2e5fd2aa244b6939600f3a86b8ef0636f5e48d9"
+"checksum verilog-filelist-parser 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e8fddb02287742f0769cbafa2ece502993c7fce85c20b2ef41d6c75d96641128"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ structopt    = "0.3"
 sv-parser    = "0.6.0"
 term         = "0.5"
 toml         = "0.4"
+verilog-filelist-parser = "0.1.0"
 
 [build-dependencies]
 regex   = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ structopt    = "0.3"
 sv-parser    = "0.6.0"
 term         = "0.5"
 toml         = "0.4"
-verilog-filelist-parser = "0.1.0"
+verilog-filelist-parser = "0.1.1"
 
 [build-dependencies]
 regex   = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,10 +261,9 @@ fn search_config(rule: &Path) -> Option<PathBuf> {
 fn parse_filelist(
     path: &Path,
 ) -> Result<(Vec<PathBuf>, Vec<PathBuf>, HashMap<String, Option<Define>>), Error> {
-    let path_str = path.to_string_lossy();
-    let filelist = match verilog_filelist_parser::parse_file(&path_str) {
+    let filelist = match verilog_filelist_parser::parse_file(path) {
         Ok(f) => f,
-        Err(_) => return Err(anyhow::anyhow!("failed to open '{}'", path_str)),
+        Err(_) => return Err(anyhow::anyhow!("failed to open '{}'", path.to_string_lossy())),
     };
     let mut defines = HashMap::new();
     for (d, t) in filelist.defines {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use sv_parser::{parse_sv, Define, DefineText};
 use svlint::config::Config;
 use svlint::linter::Linter;
 use svlint::printer::Printer;
+use verilog_filelist_parser;
 
 // -------------------------------------------------------------------------------------------------
 // Opt
@@ -260,67 +261,26 @@ fn search_config(rule: &Path) -> Option<PathBuf> {
 fn parse_filelist(
     path: &Path,
 ) -> Result<(Vec<PathBuf>, Vec<PathBuf>, HashMap<String, Option<Define>>), Error> {
-    let mut f =
-        File::open(path).with_context(|| format!("failed to open '{}'", path.to_string_lossy()))?;
-    let mut s = String::new();
-    let _ = f.read_to_string(&mut s);
-
-    let mut files = Vec::new();
-    let mut includes = Vec::new();
+    let path_str = path.to_string_lossy();
+    let filelist = match verilog_filelist_parser::parse_file(&path_str) {
+        Ok(f) => f,
+        Err(_) => return Err(anyhow::anyhow!("failed to open '{}'", path_str)),
+    };
     let mut defines = HashMap::new();
-    let re_env_brace = Regex::new(r"\$\{(?P<env>[^}]+)\}").unwrap();
-    let re_env_paren = Regex::new(r"\$\((?P<env>[^)]+)\)").unwrap();
-
-    for line in s.lines() {
-        let line = line.trim();
-        if !line.starts_with("//") && line != "" {
-            // Expand environment variable
-            let mut expanded_line = String::from(line);
-            for caps in re_env_brace.captures_iter(&line) {
-                let env = &caps["env"];
-                if let Ok(env_var) = std::env::var(env) {
-                    expanded_line = expanded_line.replace(&format!("${{{}}}", env), &env_var);
-                }
+    for (d, t) in filelist.defines {
+        match t {
+            Some(t) => {
+                let define_text = DefineText::new(String::from(&t[1..]), None);
+                let define = Define::new(String::from(&d), vec![], Some(define_text));
+                defines.insert(String::from(&d), Some(define));
             }
-            for caps in re_env_paren.captures_iter(&line) {
-                let env = &caps["env"];
-                if let Ok(env_var) = std::env::var(env) {
-                    expanded_line = expanded_line.replace(&format!("$({})", env), &env_var);
-                }
-            }
-
-            if expanded_line.starts_with("+incdir") {
-                for dir in expanded_line.trim_start_matches("+incdir+").split("+") {
-                    includes.push(PathBuf::from(dir));
-                }
-            } else if expanded_line.starts_with("+define") {
-                for define in expanded_line.trim_start_matches("+define+").split("+") {
-                    if let Some(pos) = define.find("=") {
-                        let (s, t) = define.split_at(pos);
-                        let define_text = DefineText::new(String::from(&t[1..]), None);
-                        let define = Define::new(String::from(s), vec![], Some(define_text));
-                        defines.insert(String::from(s), Some(define));
-                    } else {
-                        defines.insert(String::from(define), None);
-                    }
-                }
-            } else if expanded_line.starts_with("-f ") {
-                let path = expanded_line.trim_start_matches("-f ");
-                let (mut f, mut i, d) = parse_filelist(&PathBuf::from(path))?;
-                files.append(&mut f);
-                includes.append(&mut i);
-                for (k, v) in d {
-                    defines.insert(k, v);
-                }
-            } else if expanded_line.starts_with("-") || expanded_line.starts_with("+") {
-                // Ignore unknown options
-            } else {
-                files.push(PathBuf::from(expanded_line));
+            None => {
+                defines.insert(String::from(&d), None);
             }
         }
     }
 
-    Ok((files, includes, defines))
+    Ok((filelist.files, filelist.incdirs, defines))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
As discussed in #8, the filelist parser has been made into its own crate. The crate is [verilog-filelist-parser](https://crates.io/crates/verilog-filelist-parser)