### PR TITLE
Fixed typo

### DIFF
--- a/src/rules/function_with_automatic.rs
+++ b/src/rules/function_with_automatic.rs
@@ -26,6 +26,6 @@ impl Rule for FunctionWithAutomatic {
     }
 
     fn reason(&self) -> String {
-        String::from("this causes mismatch between simulaton and synthesis")
+        String::from("this causes mismatch between simulation and synthesis")
     }
 }

--- a/src/rules/priority_keyword.rs
+++ b/src/rules/priority_keyword.rs
@@ -20,6 +20,6 @@ impl Rule for PriorityKeyword {
     }
 
     fn reason(&self) -> String {
-        String::from("this causes mismatch between simulaton and synthesis")
+        String::from("this causes mismatch between simulation and synthesis")
     }
 }

--- a/src/rules/unique0_keyword.rs
+++ b/src/rules/unique0_keyword.rs
@@ -20,6 +20,6 @@ impl Rule for Unique0Keyword {
     }
 
     fn reason(&self) -> String {
-        String::from("this causes mismatch between simulaton and synthesis")
+        String::from("this causes mismatch between simulation and synthesis")
     }
 }

--- a/src/rules/unique_keyword.rs
+++ b/src/rules/unique_keyword.rs
@@ -20,6 +20,6 @@ impl Rule for UniqueKeyword {
     }
 
     fn reason(&self) -> String {
-        String::from("this causes mismatch between simulaton and synthesis")
+        String::from("this causes mismatch between simulation and synthesis")
     }
 }


### PR DESCRIPTION
Fixed typo
`simulaton ` -> `simulation`