### PR TITLE
Fix: Correct syntax issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "svlint"
-version = "0.4.5"
+version = "0.4.6-pre"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svlint"
-version = "0.4.5"
+version = "0.4.6-pre"
 authors = ["dalance@gmail.com"]
 repository = "https://github.com/dalance/svlint"
 keywords = ["lint", "verilog", "systemverilog"]

--- a/RULES.md
+++ b/RULES.md
@@ -83,7 +83,7 @@ multiline `for` statement must have `begin`
 
 ### Reason
 
-if there is not `begin`, the second statatement are confusing
+if there is not `begin`, the second statement are confusing
 
 ### Pass example
 
@@ -422,7 +422,7 @@ multiline `if` statement must have `begin`
 
 ### Reason
 
-if there is not `begin`, the second statatement are confusing
+if there is not `begin`, the second statement are confusing
 
 ### Pass example
 

--- a/src/rules/for_with_begin.rs
+++ b/src/rules/for_with_begin.rs
@@ -46,6 +46,6 @@ impl Rule for ForWithBegin {
     }
 
     fn reason(&self) -> String {
-        String::from("if there is not `begin`, the second statatement are confusing")
+        String::from("if there is not `begin`, the second statement are confusing")
     }
 }

--- a/src/rules/if_with_begin.rs
+++ b/src/rules/if_with_begin.rs
@@ -96,6 +96,6 @@ impl Rule for IfWithBegin {
     }
 
     fn reason(&self) -> String {
-        String::from("if there is not `begin`, the second statatement are confusing")
+        String::from("if there is not `begin`, the second statement are confusing")
     }
 }


### PR DESCRIPTION
When analysing a file with incorrect formatting, svlint
printed **statatement** instead of **statement** in some messages.
Fix this syntax issue.