### PR TITLE
New rules to forbid begin/end within always_* constructs.

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -1165,6 +1165,189 @@ end
 endmodule
 ```
 
+## sequential_block_in_always_comb
+
+### Description
+
+begin/end forbidden within `always_comb` constuct
+
+### Reason
+
+prevent introducing sequential dependencies
+
+### Pass example
+
+```SystemVerilog
+module a;
+  always_comb
+    e = z;
+
+  always_comb
+    if (foo) f = z;
+    else     f = z;
+
+  always_comb
+    case (foo)
+      one:     g = z;
+      two:     g = z;
+      default: g = z;
+    endcase
+endmodule
+```
+
+### Fail example
+
+```SystemVerilog
+module a;
+  always_comb begin
+    a = z;
+  end
+
+  always_comb
+    if (bar) begin
+      b = z;
+    end
+
+  always_comb
+    if (bar) c = z;
+    else begin
+      c = z;
+    end
+
+  always_comb
+    case (bar)
+      one: begin
+        d = z;
+      end
+      two: d = z;
+      default: d = z;
+    endcase
+endmodule
+```
+
+## sequential_block_in_always_ff
+
+### Description
+
+begin/end forbidden within `always_ff` constuct
+
+### Reason
+
+prevent introducing sequential dependencies
+
+### Pass example
+
+```SystemVerilog
+module a;
+  always_ff @(posedge clk)
+    d <= z;
+
+  always_ff @(posedge clk)
+    if (foo) e <= z;
+
+  always_ff @(posedge clk)
+    if (foo) f <= z;
+    else     f <= z;
+
+  always_ff @(posedge clk)
+    case (foo)
+      one:     g <= z;
+      two:     g <= z;
+      default: g <= z;
+    endcase
+endmodule
+```
+
+### Fail example
+
+```SystemVerilog
+module a;
+  always_ff @(posedge clk) begin
+    a <= z;
+  end
+
+  always_ff @(posedge clk)
+    if (bar) begin
+      b <= z;
+    end
+
+  always_ff @(posedge clk)
+    if (bar) c <= z;
+    else begin
+      c <= z;
+    end
+
+  always_ff @(posedge clk)
+    case (bar)
+      one: begin
+        d <= z;
+      end
+      two: d <= z;
+      default: d <= z;
+    endcase
+endmodule
+```
+
+## sequential_block_in_always_latch
+
+### Description
+
+begin/end forbidden within `always_latch` constuct
+
+### Reason
+
+prevent introducing sequential dependencies
+
+### Pass example
+
+```SystemVerilog
+module a;
+  always_latch
+    if (foo) e <= z;
+
+  always_latch
+    if (foo) f <= z;
+    else     f <= z;
+
+  always_latch
+    case (foo)
+      one:     g <= z;
+      two:     g <= z;
+      default: g <= z;
+    endcase
+endmodule
+```
+
+### Fail example
+
+```SystemVerilog
+module a;
+  always_latch begin
+    a <= z;
+  end
+
+  always_latch
+    if (bar) begin
+      b <= z;
+    end
+
+  always_latch
+    if (bar) c <= z;
+    else begin
+      c <= z;
+    end
+
+  always_latch
+    case (bar)
+      one: begin
+        d <= z;
+      end
+      two: d <= z;
+      default: d <= z;
+    endcase
+endmodule
+```
+
 ## tab_character
 
 ### Description

--- a/src/rules/sequential_block_in_always_comb.rs
+++ b/src/rules/sequential_block_in_always_comb.rs
@@ -1,0 +1,52 @@
+use crate::config::ConfigOption;
+use crate::linter::{Rule, RuleResult};
+use sv_parser::{unwrap_locate, unwrap_node, AlwaysKeyword, NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct SequentialBlockInAlwaysComb;
+
+impl Rule for SequentialBlockInAlwaysComb {
+    fn check(
+        &mut self,
+        _syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> RuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return RuleResult::Pass;
+            }
+        };
+
+        match node {
+            RefNode::AlwaysConstruct(x) => {
+                let (t, x) = &x.nodes;
+                match t {
+                    AlwaysKeyword::AlwaysComb(_) => {
+                        if let Some(x) = unwrap_node!(x, SeqBlock) {
+                            let loc = unwrap_locate!(x.clone()).unwrap();
+                            RuleResult::FailLocate(*loc)
+                        } else {
+                            RuleResult::Pass
+                        }
+                    }
+                    _ => RuleResult::Pass,
+                }
+            }
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("sequential_block_in_always_comb")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("begin/end forbidden within `always_comb` constuct")
+    }
+
+    fn reason(&self) -> String {
+        String::from("prevent introducing sequential dependencies")
+    }
+}

--- a/src/rules/sequential_block_in_always_ff.rs
+++ b/src/rules/sequential_block_in_always_ff.rs
@@ -1,0 +1,52 @@
+use crate::config::ConfigOption;
+use crate::linter::{Rule, RuleResult};
+use sv_parser::{unwrap_locate, unwrap_node, AlwaysKeyword, NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct SequentialBlockInAlwaysFf;
+
+impl Rule for SequentialBlockInAlwaysFf {
+    fn check(
+        &mut self,
+        _syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> RuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return RuleResult::Pass;
+            }
+        };
+
+        match node {
+            RefNode::AlwaysConstruct(x) => {
+                let (t, x) = &x.nodes;
+                match t {
+                    AlwaysKeyword::AlwaysFf(_) => {
+                        if let Some(x) = unwrap_node!(x, SeqBlock) {
+                            let loc = unwrap_locate!(x.clone()).unwrap();
+                            RuleResult::FailLocate(*loc)
+                        } else {
+                            RuleResult::Pass
+                        }
+                    }
+                    _ => RuleResult::Pass,
+                }
+            }
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("sequential_block_in_always_ff")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("begin/end forbidden within `always_ff` constuct")
+    }
+
+    fn reason(&self) -> String {
+        String::from("prevent introducing sequential dependencies")
+    }
+}

--- a/src/rules/sequential_block_in_always_latch.rs
+++ b/src/rules/sequential_block_in_always_latch.rs
@@ -1,0 +1,52 @@
+use crate::config::ConfigOption;
+use crate::linter::{Rule, RuleResult};
+use sv_parser::{unwrap_locate, unwrap_node, AlwaysKeyword, NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct SequentialBlockInAlwaysLatch;
+
+impl Rule for SequentialBlockInAlwaysLatch {
+    fn check(
+        &mut self,
+        _syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> RuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return RuleResult::Pass;
+            }
+        };
+
+        match node {
+            RefNode::AlwaysConstruct(x) => {
+                let (t, x) = &x.nodes;
+                match t {
+                    AlwaysKeyword::AlwaysLatch(_) => {
+                        if let Some(x) = unwrap_node!(x, SeqBlock) {
+                            let loc = unwrap_locate!(x.clone()).unwrap();
+                            RuleResult::FailLocate(*loc)
+                        } else {
+                            RuleResult::Pass
+                        }
+                    }
+                    _ => RuleResult::Pass,
+                }
+            }
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("sequential_block_in_always_latch")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("begin/end forbidden within `always_latch` constuct")
+    }
+
+    fn reason(&self) -> String {
+        String::from("prevent introducing sequential dependencies")
+    }
+}

--- a/testcases/fail/sequential_block_in_always_comb.sv
+++ b/testcases/fail/sequential_block_in_always_comb.sv
@@ -1,0 +1,25 @@
+module a;
+  always_comb begin
+    a = z;
+  end
+
+  always_comb
+    if (bar) begin
+      b = z;
+    end
+
+  always_comb
+    if (bar) c = z;
+    else begin
+      c = z;
+    end
+
+  always_comb
+    case (bar)
+      one: begin
+        d = z;
+      end
+      two: d = z;
+      default: d = z;
+    endcase
+endmodule

--- a/testcases/fail/sequential_block_in_always_ff.sv
+++ b/testcases/fail/sequential_block_in_always_ff.sv
@@ -1,0 +1,25 @@
+module a;
+  always_ff @(posedge clk) begin
+    a <= z;
+  end
+
+  always_ff @(posedge clk)
+    if (bar) begin
+      b <= z;
+    end
+
+  always_ff @(posedge clk)
+    if (bar) c <= z;
+    else begin
+      c <= z;
+    end
+
+  always_ff @(posedge clk)
+    case (bar)
+      one: begin
+        d <= z;
+      end
+      two: d <= z;
+      default: d <= z;
+    endcase
+endmodule

--- a/testcases/fail/sequential_block_in_always_latch.sv
+++ b/testcases/fail/sequential_block_in_always_latch.sv
@@ -1,0 +1,25 @@
+module a;
+  always_latch begin
+    a <= z;
+  end
+
+  always_latch
+    if (bar) begin
+      b <= z;
+    end
+
+  always_latch
+    if (bar) c <= z;
+    else begin
+      c <= z;
+    end
+
+  always_latch
+    case (bar)
+      one: begin
+        d <= z;
+      end
+      two: d <= z;
+      default: d <= z;
+    endcase
+endmodule

--- a/testcases/pass/sequential_block_in_always_comb.sv
+++ b/testcases/pass/sequential_block_in_always_comb.sv
@@ -1,0 +1,15 @@
+module a;
+  always_comb
+    e = z;
+
+  always_comb
+    if (foo) f = z;
+    else     f = z;
+
+  always_comb
+    case (foo)
+      one:     g = z;
+      two:     g = z;
+      default: g = z;
+    endcase
+endmodule

--- a/testcases/pass/sequential_block_in_always_ff.sv
+++ b/testcases/pass/sequential_block_in_always_ff.sv
@@ -1,0 +1,18 @@
+module a;
+  always_ff @(posedge clk)
+    d <= z;
+
+  always_ff @(posedge clk)
+    if (foo) e <= z;
+
+  always_ff @(posedge clk)
+    if (foo) f <= z;
+    else     f <= z;
+
+  always_ff @(posedge clk)
+    case (foo)
+      one:     g <= z;
+      two:     g <= z;
+      default: g <= z;
+    endcase
+endmodule

--- a/testcases/pass/sequential_block_in_always_latch.sv
+++ b/testcases/pass/sequential_block_in_always_latch.sv
@@ -1,0 +1,15 @@
+module a;
+  always_latch
+    if (foo) e <= z;
+
+  always_latch
+    if (foo) f <= z;
+    else     f <= z;
+
+  always_latch
+    case (foo)
+      one:     g <= z;
+      two:     g <= z;
+      default: g <= z;
+    endcase
+endmodule


### PR DESCRIPTION
These rules are useful to prevent unwittingly introducing sequential dependencies, which would mismatch synthesis. E.g.
```
always_comb begin
  a = expensive_function(y); // Woops! Computed on update of z.
  b = z;
end
```

Another effect of these rules is that flops become easier to audit. E.g. this sort of thing is prevented:
```
always_ff @ (posedge clk)
  if (rst) begin
    a <= 0;
    // Woops! Forgot to reset b.
  end else begin
    a <= z;
    b <= y;
  end
```