### PR TITLE
New rules for parameter/localparam types.

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -764,6 +764,38 @@ localparam a = 0;
 endmodule
 ```
 
+## localparam_type_twostate
+
+### Description
+
+`localparam` must be have a twostate type
+
+### Reason
+
+design constants should not contain X or Z bits.
+
+### Pass example
+
+```SystemVerilog
+module A;
+  localparam byte     a = 0; // 8b
+  localparam shortint b = 0; // 16b
+  localparam int      c = 0; // 32b
+  localparam longint  d = 0; // 64b
+  localparam bit      e = 0; // 1b
+endmodule
+```
+
+### Fail example
+
+```SystemVerilog
+module A;
+  localparam integer a = 0; // 32b
+  localparam logic   b = 0; // 1b
+  localparam reg     c = 0; // 1b
+endmodule
+```
+
 ## loop_variable_declaration
 
 ### Description
@@ -1001,6 +1033,40 @@ endpackage
 package A;
 parameter A = 1;
 endpackage
+```
+
+## parameter_type_twostate
+
+### Description
+
+`parameter` must be have a twostate type
+
+### Reason
+
+design constants should not contain X or Z bits.
+
+### Pass example
+
+```SystemVerilog
+module A #(
+  parameter byte     a = 0, // 8b
+  parameter shortint b = 0, // 16b
+  parameter int      c = 0, // 32b
+  parameter longint  d = 0, // 64b
+  parameter bit      e = 0  // 1b
+) ();
+endmodule
+```
+
+### Fail example
+
+```SystemVerilog
+module A #(
+  parameter integer a = 0, // 32b
+  parameter logic   b = 0, // 1b
+  parameter reg     c = 0  // 1b
+) ();
+endmodule
 ```
 
 ## prefix_inout

--- a/RULES.md
+++ b/RULES.md
@@ -738,6 +738,32 @@ end
 endmodule
 ```
 
+## localparam_explicit_type
+
+### Description
+
+`localparam` must be have an explicit type
+
+### Reason
+
+parameter types show intent and improve readability
+
+### Pass example
+
+```SystemVerilog
+module A;
+localparam int a = 0;
+endmodule
+```
+
+### Fail example
+
+```SystemVerilog
+module A;
+localparam a = 0;
+endmodule
+```
+
 ## loop_variable_declaration
 
 ### Description
@@ -924,6 +950,30 @@ endmodule
 module A (
     output logic a
 );
+endmodule
+```
+
+## parameter_explicit_type
+
+### Description
+
+`parameter` must be have an explicit type
+
+### Reason
+
+parameter types show intent and improve readability
+
+### Pass example
+
+```SystemVerilog
+module A #(parameter int a = 0) ();
+endmodule
+```
+
+### Fail example
+
+```SystemVerilog
+module A #(parameter a = 0) ();
 endmodule
 ```
 

--- a/src/rules/localparam_explicit_type.rs
+++ b/src/rules/localparam_explicit_type.rs
@@ -1,0 +1,45 @@
+use crate::config::ConfigOption;
+use crate::linter::{Rule, RuleResult};
+use sv_parser::{unwrap_node, NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct LocalparamExplicitType;
+
+impl Rule for LocalparamExplicitType {
+    fn check(
+        &mut self,
+        _syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> RuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return RuleResult::Pass;
+            }
+        };
+        match node {
+            RefNode::LocalParameterDeclarationParam(x) => {
+                let t = unwrap_node!(*x, ImplicitDataType);
+                if t.is_some() {
+                    RuleResult::Fail
+                } else {
+                    RuleResult::Pass
+                }
+            }
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("localparam_explicit_type")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("`localparam` must be have an explicit type")
+    }
+
+    fn reason(&self) -> String {
+        String::from("parameter types show intent and improve readability")
+    }
+}

--- a/src/rules/localparam_type_twostate.rs
+++ b/src/rules/localparam_type_twostate.rs
@@ -1,0 +1,65 @@
+use crate::config::ConfigOption;
+use crate::linter::{Rule, RuleResult};
+use sv_parser::{
+    unwrap_node, DataType, IntegerAtomType, IntegerVectorType, NodeEvent, RefNode, SyntaxTree,
+};
+
+#[derive(Default)]
+pub struct LocalparamTypeTwostate;
+
+impl Rule for LocalparamTypeTwostate {
+    fn check(
+        &mut self,
+        _syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> RuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return RuleResult::Pass;
+            }
+        };
+        match node {
+            RefNode::LocalParameterDeclarationParam(x) => {
+                // struct
+                let t = unwrap_node!(*x, DataType);
+                match t {
+                    Some(RefNode::DataType(DataType::Atom(x))) => {
+                        let (t, _) = &x.nodes;
+                        match t {
+                            IntegerAtomType::Integer(_) => RuleResult::Fail,
+                            _ => RuleResult::Pass,
+                        }
+                    }
+
+                    Some(RefNode::DataType(DataType::Vector(x))) => {
+                        let (t, _, _) = &x.nodes;
+                        match t {
+                            IntegerVectorType::Logic(_) | IntegerVectorType::Reg(_) => {
+                                RuleResult::Fail
+                            }
+                            _ => RuleResult::Pass,
+                        }
+                    }
+
+                    // Non-integer type -> verif not a synthesizable design.
+                    _ => RuleResult::Pass,
+                }
+            }
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("localparam_type_twostate")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("`localparam` must be have a twostate type")
+    }
+
+    fn reason(&self) -> String {
+        String::from("design constants should not contain X or Z bits.")
+    }
+}

--- a/src/rules/parameter_explicit_type.rs
+++ b/src/rules/parameter_explicit_type.rs
@@ -1,0 +1,45 @@
+use crate::config::ConfigOption;
+use crate::linter::{Rule, RuleResult};
+use sv_parser::{unwrap_node, NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct ParameterExplicitType;
+
+impl Rule for ParameterExplicitType {
+    fn check(
+        &mut self,
+        _syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> RuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return RuleResult::Pass;
+            }
+        };
+        match node {
+            RefNode::ParameterDeclarationParam(x) => {
+                let t = unwrap_node!(*x, ImplicitDataType);
+                if t.is_some() {
+                    RuleResult::Fail
+                } else {
+                    RuleResult::Pass
+                }
+            }
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("parameter_explicit_type")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("`parameter` must be have an explicit type")
+    }
+
+    fn reason(&self) -> String {
+        String::from("parameter types show intent and improve readability")
+    }
+}

--- a/src/rules/parameter_type_twostate.rs
+++ b/src/rules/parameter_type_twostate.rs
@@ -1,0 +1,65 @@
+use crate::config::ConfigOption;
+use crate::linter::{Rule, RuleResult};
+use sv_parser::{
+    unwrap_node, DataType, IntegerAtomType, IntegerVectorType, NodeEvent, RefNode, SyntaxTree,
+};
+
+#[derive(Default)]
+pub struct ParameterTypeTwostate;
+
+impl Rule for ParameterTypeTwostate {
+    fn check(
+        &mut self,
+        _syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> RuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return RuleResult::Pass;
+            }
+        };
+        match node {
+            RefNode::ParameterDeclarationParam(x) => {
+                // struct
+                let t = unwrap_node!(*x, DataType);
+                match t {
+                    Some(RefNode::DataType(DataType::Atom(x))) => {
+                        let (t, _) = &x.nodes;
+                        match t {
+                            IntegerAtomType::Integer(_) => RuleResult::Fail,
+                            _ => RuleResult::Pass,
+                        }
+                    }
+
+                    Some(RefNode::DataType(DataType::Vector(x))) => {
+                        let (t, _, _) = &x.nodes;
+                        match t {
+                            IntegerVectorType::Logic(_) | IntegerVectorType::Reg(_) => {
+                                RuleResult::Fail
+                            }
+                            _ => RuleResult::Pass,
+                        }
+                    }
+
+                    // Non-integer type -> verif not a synthesizable design.
+                    _ => RuleResult::Pass,
+                }
+            }
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("parameter_type_twostate")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("`parameter` must be have a twostate type")
+    }
+
+    fn reason(&self) -> String {
+        String::from("design constants should not contain X or Z bits.")
+    }
+}

--- a/testcases/fail/localparam_explicit_type.sv
+++ b/testcases/fail/localparam_explicit_type.sv
@@ -1,0 +1,3 @@
+module A;
+localparam a = 0;
+endmodule

--- a/testcases/fail/localparam_type_twostate.sv
+++ b/testcases/fail/localparam_type_twostate.sv
@@ -1,0 +1,5 @@
+module A;
+  localparam integer a = 0; // 32b
+  localparam logic   b = 0; // 1b
+  localparam reg     c = 0; // 1b
+endmodule

--- a/testcases/fail/parameter_explicit_type.sv
+++ b/testcases/fail/parameter_explicit_type.sv
@@ -1,0 +1,2 @@
+module A #(parameter a = 0) ();
+endmodule

--- a/testcases/fail/parameter_type_twostate.sv
+++ b/testcases/fail/parameter_type_twostate.sv
@@ -1,0 +1,6 @@
+module A #(
+  parameter integer a = 0, // 32b
+  parameter logic   b = 0, // 1b
+  parameter reg     c = 0  // 1b
+) ();
+endmodule

--- a/testcases/pass/localparam_explicit_type.sv
+++ b/testcases/pass/localparam_explicit_type.sv
@@ -1,0 +1,3 @@
+module A;
+localparam int a = 0;
+endmodule

--- a/testcases/pass/localparam_type_twostate.sv
+++ b/testcases/pass/localparam_type_twostate.sv
@@ -1,0 +1,7 @@
+module A;
+  localparam byte     a = 0; // 8b
+  localparam shortint b = 0; // 16b
+  localparam int      c = 0; // 32b
+  localparam longint  d = 0; // 64b
+  localparam bit      e = 0; // 1b
+endmodule

--- a/testcases/pass/parameter_explicit_type.sv
+++ b/testcases/pass/parameter_explicit_type.sv
@@ -1,0 +1,2 @@
+module A #(parameter int a = 0) ();
+endmodule

--- a/testcases/pass/parameter_type_twostate.sv
+++ b/testcases/pass/parameter_type_twostate.sv
@@ -1,0 +1,8 @@
+module A #(
+  parameter byte     a = 0, // 8b
+  parameter shortint b = 0, // 16b
+  parameter int      c = 0, // 32b
+  parameter longint  d = 0, // 64b
+  parameter bit      e = 0  // 1b
+) ();
+endmodule


### PR DESCRIPTION
- `(localparam|parameter)_explicit_type` Ensures that types are specified to clarify intent.
- `(localparam|parameter)_type_twostate` Ensures that parameters are twostate.