### PR TITLE
Apply case_default to always_ff (in addition to always_comb and functions)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -34,7 +34,7 @@ endmodule
 
 ### Description
 
-`case` must have `default` in `always_comb` or `function`
+`case` must have `default` in `always_comb`, `always_ff` or `function`
 
 ### Reason
 
@@ -53,6 +53,7 @@ end
 always_ff begin
     case (x)
         1: y = 0;
+        default: y = 0;
     endcase
 end
 endmodule

--- a/src/rules/case_default.rs
+++ b/src/rules/case_default.rs
@@ -22,7 +22,7 @@ impl Rule for CaseDefault {
             RefNode::AlwaysConstruct(x) => {
                 let (ref a, _) = x.nodes;
                 match a {
-                    AlwaysKeyword::AlwaysComb(_) => {
+                    AlwaysKeyword::AlwaysComb(_) | AlwaysKeyword::AlwaysFf(_) => {
                         if let Some(x) = unwrap_node!(*x, CaseStatementNormal) {
                             let loc = unwrap_locate!(x.clone()).unwrap();
                             let a = unwrap_node!(x, CaseItemDefault);
@@ -60,7 +60,7 @@ impl Rule for CaseDefault {
     }
 
     fn hint(&self, _option: &ConfigOption) -> String {
-        String::from("`case` must have `default` in `always_comb` or `function`")
+        String::from("`case` must have `default` in `always_comb`, `always_ff` or `function`")
     }
 
     fn reason(&self) -> String {

--- a/testcases/pass/case_default.sv
+++ b/testcases/pass/case_default.sv
@@ -8,6 +8,7 @@ end
 always_ff begin
     case (x)
         1: y = 0;
+        default: y = 0;
     endcase
 end
 endmodule


### PR DESCRIPTION
An incompletely-specified `case` doesn't necessarily cause a sim/synth mismatch in `always_ff`, but an explicit `default` makes the design intent clearer.

This is similar to requiring `else` for every `if`, though I'll make a different PR for that.

@dalance Should this be a separate rule like `case_default_always_ff`?