### PR TITLE
Take configuration file from environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ cargo install svlint
 First of all, you must put a configuration file `.svlint.toml` to specify enabled rules.
 Configuration file is searched to the upper directory until `/`.
 So you can put configuration file (`.svlint.toml`) on the repository root like `.gitignore`.
+Alternatively, for project-wide rules you can set the environment variable
+`SVLINT_CONFIG` to something like `/cad/projectFoo/teamBar.svlint.toml`.
 
 The example of configuration file is below:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,6 +269,19 @@ fn print_parse_error(
 
 #[cfg_attr(tarpaulin, skip)]
 fn search_config(rule: &Path) -> Option<PathBuf> {
+    if let Ok(c) = env::var("SVLINT_CONFIG") {
+        let candidate = Path::new(&c);
+        if candidate.exists() {
+            return Some(candidate.to_path_buf());
+        } else {
+            let mut printer = Printer::new();
+            printer.print_warning(&format!(
+                "SVLINT_CONFIG=\"{}\" does not exist. Searching hierarchically.",
+                c,
+            )).ok()?;
+        }
+    }
+
     if let Ok(current) = env::current_dir() {
         for dir in current.ancestors() {
             let candidate = dir.join(rule);

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ fn print_parse_error(
 }
 
 #[cfg_attr(tarpaulin, skip)]
-fn search_config(rule: &Path) -> Option<PathBuf> {
+fn search_config(config: &Path) -> Option<PathBuf> {
     if let Ok(c) = env::var("SVLINT_CONFIG") {
         let candidate = Path::new(&c);
         if candidate.exists() {
@@ -284,7 +284,7 @@ fn search_config(rule: &Path) -> Option<PathBuf> {
 
     if let Ok(current) = env::current_dir() {
         for dir in current.ancestors() {
-            let candidate = dir.join(rule);
+            let candidate = dir.join(config);
             if candidate.exists() {
                 return Some(candidate);
             }


### PR DESCRIPTION
Look for special envvar SVLINT_CONFIG.
If SVLINT_CONFIG is not set (as currently), then hierarchical search (no change).
If SVLINT_CONFIG is set but is invalid, then hierarchical search (no change).
If SVLINT_CONFIG is set AND --config is given, then use SVLINT_CONFIG.

Enables use with standardised environments like GNU Modulefiles.
E.g. `$ module load svlint` would append to PATH and set SVLINT_CONFIG.
Or, more realistically, `$ module load projectFoo` would set environment
variables for all the project's tools (where svlint is one of many).
Different projects can then have different rule-sets, and everybody working
on the same project uses the same rule-set.

There's a partner PR at https://github.com/dalance/svls/pull/120