### PR TITLE
New flag `--dump-filelist` to help debug filelist issues.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -342,10 +342,15 @@ fn dump_filelist(
     }
 
     println!("  defines:");
-    for (d, t) in defines {
-        match t {
-            None => println!("    {:?}:", d),
-            Some(te) => println!("    {:?}: {:?}", d, te),
+    for (k, v) in defines {
+        match v {
+            None => println!("    {:?}:", k),
+            Some(define) => {
+                match &define.text {
+                    Some(definetext) => println!("    {:?}: {:?}", k, definetext.text),
+                    None => println!("    {:?}:", k),
+                }
+            }
         };
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,7 +310,7 @@ fn parse_filelist(
     for (d, t) in filelist.defines {
         match t {
             Some(t) => {
-                let define_text = DefineText::new(String::from(&t[1..]), None);
+                let define_text = DefineText::new(String::from(&t), None);
                 let define = Define::new(String::from(&d), vec![], Some(define_text));
                 defines.insert(String::from(&d), Some(define));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,10 @@ pub struct Opt {
     /// Prints config example
     #[clap(long = "example")]
     pub example: bool,
+
+    /// Prints data from filelists
+    #[clap(long = "dump-filelist")]
+    pub dump_filelist: bool,
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -192,11 +196,18 @@ pub fn run_opt_config(opt: &Opt, config: Config) -> Result<bool, Error> {
 
         for filelist in &opt.filelist {
             let (mut f, mut i, d) = parse_filelist(filelist)?;
+            if opt.dump_filelist {
+                dump_filelist(&filelist, &f, &i, &d);
+            }
             files.append(&mut f);
             includes.append(&mut i);
             for (k, v) in d {
                 defines.insert(k, v);
             }
+        }
+        if opt.dump_filelist {
+            dump_filelist(&Path::new("."), &files, &includes, &defines);
+            return Ok(true);
         }
 
         (files, includes)
@@ -310,6 +321,33 @@ fn parse_filelist(
     }
 
     Ok((filelist.files, filelist.incdirs, defines))
+}
+
+fn dump_filelist(
+    filename: &Path,
+    files: &Vec<PathBuf>,
+    incdirs: &Vec<PathBuf>,
+    defines: &HashMap<String, Option<Define>>,
+) -> () {
+    println!("{:?}:", filename);
+
+    println!("  files:");
+    for f in files {
+        println!("    - {:?}", f);
+    }
+
+    println!("  incdirs:");
+    for i in incdirs {
+        println!("    - {:?}", i);
+    }
+
+    println!("  defines:");
+    for (d, t) in defines {
+        match t {
+            None => println!("    {:?}:", d),
+            Some(te) => println!("    {:?}: {:?}", d, te),
+        };
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Based on <https://github.com/Raamakrishnan/verilog-filelist-parser/pull/2>.
@Raamakrishnan This is indeed a better place for such a debug-aid.

Exposed and fixed bug where first character was dropped from define strings.
E.g. In a filelist, `+define+FOO=bar` was resulting in a define with identifer `FOO` (correct) and a value `ar` (incorrect).

Each filelist is printed in YAML format (because it's easy and no dependencies).
As filelists can override each other's defines, the final result is printed with `.` as the filename.