### PR TITLE
Fix warnings on `cargo test`.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,7 @@ mod tests {
         } else {
             vec!["svlint", &file]
         };
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_opt_config(&opt, config.clone());
         assert_eq!(ret.unwrap(), true);
 
@@ -336,7 +336,7 @@ mod tests {
         } else {
             vec!["svlint", &file]
         };
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_opt_config(&opt, config.clone());
         assert_eq!(ret.unwrap(), false);
 
@@ -346,7 +346,7 @@ mod tests {
         } else {
             vec!["svlint", "-1", &file]
         };
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_opt_config(&opt, config.clone());
         assert_eq!(ret.unwrap(), false);
     }


### PR DESCRIPTION
Change `from_iter` (deprecated) to `parse_from`.
<https://docs.rs/clap/latest/src/clap/derive.rs.html#101-118>
<https://docs.rs/clap/latest/src/clap/derive.rs.html#195-206>