### PR TITLE
Silent flag silences .toml not found message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -148,10 +148,12 @@ pub fn run_opt(opt: &Opt) -> Result<bool, Error> {
 
         ret
     } else {
-        println!(
-            "Config file '{}' is not found. Enable all rules",
-            opt.config.to_string_lossy()
-        );
+        if !opt.silent {
+            println!(
+                "Config file '{}' is not found. Enable all rules",
+                opt.config.to_string_lossy()
+            );
+        }
         Config::new().enable_all()
     };
 


### PR DESCRIPTION
We are using svlint to read filelists and currently the message `Config file is not found. Enable all rules` may/may not be output, depending on whether the file exists in the workspace or if `$SVLINT_CONFIG` is set. This is to add predictable output.

This would also allow dalance/svls-vscode#9 to be implemented, via a setting that adds `--silent` to the command.