### PR TITLE
Relax style rule on assign keyword.

### DIFF
--- a/src/rules/style_keyword_1space.rs
+++ b/src/rules/style_keyword_1space.rs
@@ -21,7 +21,7 @@ impl Rule for StyleKeyword1Space {
         re_split extracts keyword from anything following it.
         re_kw is used to selectively apply this rule to specific keywords.
         re_succ matches what is allowed after the keyword.
-            - exactly 1space
+            - exactly 1space, then nothing
         */
         if self.re_split.is_none() {
             self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
@@ -34,7 +34,6 @@ impl Rule for StyleKeyword1Space {
                 , "always_ff"
                 , "and"
                 , "assert"
-                , "assign"
                 , "assume"
                 , "automatic"
                 , "before"

--- a/src/rules/style_keyword_construct.rs
+++ b/src/rules/style_keyword_construct.rs
@@ -32,6 +32,7 @@ impl Rule for StyleKeywordConstruct {
             let keywords =
                 [ "always_comb" // {{{
                 , "always_latch"
+                , "assign"
                 , "else"
                 , "final"
                 , "generate"


### PR DESCRIPTION
Allow indented assignment to with concatenation on LHS.

This code structure is useful for tying off lots of wires:
```systemverilog
assign
  { foo
  , bar
  , baz[i][j][k]
  } = '0
```

The equivalent using `always_comb` is already allowed. All code which passed before this commit, still passes.