### PR TITLE
Distinguish between parse/preprocess errors. Bump sv-parser.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde                   = "1.0"
 serde_derive            = "1.0"
 serde_regex             = "1.1"
 clap                    = {version = "3.1.18", features = ["derive"]}
-sv-parser               = "0.12.1"
+sv-parser               = "0.12.2"
 term                    = "0.7"
 toml                    = "0.5"
 sv-filelist-parser      = "0.1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,7 +233,7 @@ pub fn run_opt_config(opt: &Opt, config: Config) -> Result<bool, Error> {
                     defines = new_defines;
                 }
                 Err(x) => {
-                    print_parse_error(&mut printer, x, opt.single)?;
+                    print_parser_error(&mut printer, x, opt.single)?;
                     pass = false;
                 }
             }
@@ -251,7 +251,7 @@ pub fn run_opt_config(opt: &Opt, config: Config) -> Result<bool, Error> {
                     defines = new_defines;
                 }
                 Err(x) => {
-                    print_parse_error(&mut printer, x, opt.single)?;
+                    print_parser_error(&mut printer, x, opt.single)?;
                     pass = false;
                 }
             }
@@ -270,7 +270,7 @@ pub fn run_opt_config(opt: &Opt, config: Config) -> Result<bool, Error> {
 }
 
 #[cfg_attr(tarpaulin, skip)]
-fn print_parse_error(
+fn print_parser_error(
     printer: &mut Printer,
     error: SvParserError,
     single: bool,
@@ -278,6 +278,9 @@ fn print_parse_error(
     match error {
         SvParserError::Parse(Some((path, pos))) => {
             printer.print_parse_error(&path, pos, single)?;
+        }
+        SvParserError::Preprocess(Some((path, pos))) => {
+            printer.print_preprocess_error(&path, pos, single)?;
         }
         SvParserError::Include { source: x } => {
             if let SvParserError::File { path: x, .. } = *x {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -364,6 +364,26 @@ impl Printer {
     }
 
     #[cfg_attr(tarpaulin, skip)]
+    pub fn print_preprocess_error(
+        &mut self,
+        path: &Path,
+        error_pos: usize,
+        single: bool,
+    ) -> Result<(), Error> {
+        let mut f = File::open(path)
+            .with_context(|| format!("failed to open: '{}'", path.to_string_lossy()))?;
+        let mut s = String::new();
+        let _ = f.read_to_string(&mut s);
+
+        if single {
+            self.print_single(&s, error_pos, "Error", path, Some("preprocess error"));
+        } else {
+            self.print_pretty(&s, error_pos, 1, "Error", "preprocess error", path, None, None);
+        }
+        Ok(())
+    }
+
+    #[cfg_attr(tarpaulin, skip)]
     pub fn print_error(&mut self, error: &str) -> Result<(), Error> {
         self.write("Error", Color::BrightRed);
         self.write(&format!(": {}", error), Color::BrightWhite);


### PR DESCRIPTION
- Depends on corresponding PR in sv-parser: https://github.com/dalance/sv-parser/pull/69
- Rename `main.rs`'s `print_parse_error()` -> `print_parser_error()` to avoid confusion with function of the same name in `printer.rs`.
- New function `print_preprocess_error` is essentially the same as `print_parse_error` but allows users to distinguish pp parse errors.
- Bump sv-parser from 0.12.1 to 0.12.2.