### PR TITLE
Bugfix #182 explicit_if_else, explicit_case_default

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -149,36 +149,40 @@ explicit `default` makes design intent clearer
 ### Pass example
 
 ```SystemVerilog
-module A;
-always_comb begin
+module M;
+  always_comb
     case (x)
-        1: y = 0;
-        default: y = 0;
+      1: y = 0;
+      default: y = 0;
     endcase
-end
-always_ff begin
+
+  always_ff @(clk)
     case (x)
-        1: y = 0;
-        default: y = 0;
+      1: y = 0;
+      default: y = 0;
     endcase
-end
 endmodule
 ```
 
 ### Fail example
 
 ```SystemVerilog
-module A;
-always_comb begin
+module M;
+  always_comb
     case (x)
-        1: y = 0;
+      1: y = 0; // Incompletely specified case implies memory.
     endcase
-end
-always_ff begin
+
+  always_ff @(clk) begin
     case (x)
-        1: y = 0;
+      1: y = 0;
+      default: y = 0; // Explicit default arm is good.
     endcase
-end
+
+    case (y)
+      1: y = 0; // Implicit default arm.
+    endcase
+  end
 endmodule
 ```
 
@@ -195,22 +199,33 @@ explicit `else` makes design intent clearer
 ### Pass example
 
 ```SystemVerilog
-module A;
-always_ff
-  if (x) y <= 0;
-  else   y <= z;
-always_comb
-  if (x) y = 0;
-  else   y = z;
+module M;
+  always_ff @(clk)
+    if (x) y <= 0;
+    else   y <= z;
+
+  always_comb
+    if (x) y = 0;
+    else   y = z;
 endmodule
 ```
 
 ### Fail example
 
 ```SystemVerilog
-module A;
-always_ff if (x) y <= 0;
-always_comb if (x) y = 0;
+module M;
+  always_comb
+    if (x) y = 0; // Incompletely specified condition implies memory.
+
+  always_ff @(clk) begin
+    if (a)
+      b <= c;
+    else // Explicit else clause is good.
+      b <= d;
+
+    if (b)
+      c <= d; // Implicit else clause.
+  end
 endmodule
 ```
 

--- a/src/rules/explicit_if_else.rs
+++ b/src/rules/explicit_if_else.rs
@@ -35,8 +35,8 @@ impl Rule for ExplicitIfElse {
             }
         };
         match (self.under_always_construct, node) {
-            (true, RefNode::ConditionalStatement(y)) => {
-                let (_, ref b, _, _, _, ref f) = &y.nodes;
+            (true, RefNode::ConditionalStatement(x)) => {
+                let (_, ref b, _, _, _, ref f) = &x.nodes;
                 let loc = unwrap_locate!(b).unwrap();
                 if f.is_none() {
                     RuleResult::FailLocate(*loc)

--- a/testcases/fail/explicit_case_default.sv
+++ b/testcases/fail/explicit_case_default.sv
@@ -1,12 +1,17 @@
-module A;
-always_comb begin
+module M;
+  always_comb
     case (x)
-        1: y = 0;
+      1: y = 0; // Incompletely specified case implies memory.
     endcase
-end
-always_ff begin
+
+  always_ff @(clk) begin
     case (x)
-        1: y = 0;
+      1: y = 0;
+      default: y = 0; // Explicit default arm is good.
     endcase
-end
+
+    case (y)
+      1: y = 0; // Implicit default arm.
+    endcase
+  end
 endmodule

--- a/testcases/fail/explicit_if_else.sv
+++ b/testcases/fail/explicit_if_else.sv
@@ -1,4 +1,14 @@
-module A;
-always_ff if (x) y <= 0;
-always_comb if (x) y = 0;
+module M;
+  always_comb
+    if (x) y = 0; // Incompletely specified condition implies memory.
+
+  always_ff @(clk) begin
+    if (a)
+      b <= c;
+    else // Explicit else clause is good.
+      b <= d;
+
+    if (b)
+      c <= d; // Implicit else clause.
+  end
 endmodule

--- a/testcases/pass/explicit_case_default.sv
+++ b/testcases/pass/explicit_case_default.sv
@@ -1,14 +1,13 @@
-module A;
-always_comb begin
+module M;
+  always_comb
     case (x)
-        1: y = 0;
-        default: y = 0;
+      1: y = 0;
+      default: y = 0;
     endcase
-end
-always_ff begin
+
+  always_ff @(clk)
     case (x)
-        1: y = 0;
-        default: y = 0;
+      1: y = 0;
+      default: y = 0;
     endcase
-end
 endmodule

--- a/testcases/pass/explicit_if_else.sv
+++ b/testcases/pass/explicit_if_else.sv
@@ -1,8 +1,9 @@
-module A;
-always_ff
-  if (x) y <= 0;
-  else   y <= z;
-always_comb
-  if (x) y = 0;
-  else   y = z;
+module M;
+  always_ff @(clk)
+    if (x) y <= 0;
+    else   y <= z;
+
+  always_comb
+    if (x) y = 0;
+    else   y = z;
 endmodule


### PR DESCRIPTION
@supleed2 Thanks for finding #182 and the testcases.
The problem was using `unwrap_node!()` which only returns the first instance.
This PR uses a 1b FSM which is set whenever an AlwaysConstruct is entered, and cleared on exit.