### PR TITLE
dumpSyntaxtree Add `--dump-syntaxtree` using Debug trait.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ pub struct Opt {
     )]
     pub defines: Vec<String>,
 
-    /// Include path
+    /// Include directory path
     #[clap(
         short = 'i',
         long = "include",
@@ -47,7 +47,7 @@ pub struct Opt {
     )]
     pub includes: Vec<PathBuf>,
 
-    /// Config file
+    /// TOML configuration file
     #[clap(short = 'c', long = "config", default_value = ".svlint.toml")]
     pub config: PathBuf,
 
@@ -64,31 +64,31 @@ pub struct Opt {
     #[clap(long = "ignore-include")]
     pub ignore_include: bool,
 
-    /// Prints results by single line
+    /// Print results by single line
     #[clap(short = '1')]
     pub single: bool,
 
-    /// Suppresses message
+    /// Suppress messages
     #[clap(short = 's', long = "silent")]
     pub silent: bool,
 
-    /// Prints verbose message
+    /// Print verbose messages
     #[clap(short = 'v', long = "verbose")]
     pub verbose: bool,
 
-    /// Prints message for GitHub Actions
+    /// Print message for GitHub Actions
     #[clap(long = "github-actions")]
     pub github_actions: bool,
 
-    /// Updates config
+    /// Update configuration
     #[clap(long = "update")]
     pub update_config: bool,
 
-    /// Prints config example
+    /// Print TOML configuration example
     #[clap(long = "example")]
     pub example: bool,
 
-    /// Prints data from filelists
+    /// Print data from filelists
     #[clap(long = "dump-filelist")]
     pub dump_filelist: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,10 @@ pub struct Opt {
     #[clap(long = "dump-filelist")]
     pub dump_filelist: bool,
 
+    /// Print syntax trees
+    #[clap(long = "dump-syntaxtree")]
+    pub dump_syntaxtree: bool,
+
     /// Print preprocessor output instead of performing checks
     #[clap(short = 'E')]
     pub preprocess_only: bool,
@@ -249,6 +253,10 @@ pub fn run_opt_config(opt: &Opt, config: Config) -> Result<bool, Error> {
                         }
                     }
                     defines = new_defines;
+
+                    if !opt.dump_syntaxtree {
+                        println!("{:?}", &syntax_tree);
+                    }
                 }
                 Err(x) => {
                     print_parse_error(&mut printer, x, opt.single)?;


### PR DESCRIPTION

- Useful for debugging exactly how whitespace/style rules work,
  or any rule which works on WhiteSpace nodes.
- Depends on <https://github.com/dalance/sv-parser/pull/70>
- Minor wording updates to argument descriptions - mostly to use imperative mood consistently.