### PR TITLE
New Rule: `action_block_with_side_effect`

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -149,6 +149,90 @@ a short reason why it should be seen.
 
 
 ---
+## `action_block_with_side_effect`
+
+### Hint
+
+Do not specify side effects within `assert` or `wait_order` action blocks.
+
+### Reason
+
+Side effects may cause undefined event ordering.
+
+### Pass Example
+
+```SystemVerilog
+module M;
+  always @(posedge clk)
+    assert (A)
+      else $error("A should be high.");
+
+  // Simulator must report line number, label, and time on each violation.
+  asrt_b1: assert property (@(posedge clk) B1)
+    else $error("B1 should be high.");
+  asrt_b2: assert property (@(posedge clk) B2)
+    else $error("B2 should be high.");
+endmodule
+```
+
+### Fail Example
+
+```SystemVerilog
+module M;
+  always @(posedge clk)
+    assert (A) // These are legal, but potentially confusing.
+    else begin
+      $display("A should be high."); // Write to STDOUT.
+
+      // Update global variable.
+      errorId = 5; // What value if multiple immediate assertions fail?
+      errorCount++; // Hopefully simulator blocks between processes.
+    end
+
+  // In what order do these action blocks occur?
+  asrt_b1: assert property (@(posedge clk) B1)
+    else begin
+      $display("B1 should be high.");
+      errorId = 1;
+      errorCount++;
+    end;
+  asrt_b2: assert property (@(posedge clk) B2)
+    else begin
+      $display("B2 should be high.");
+      errorId = 2;
+      errorCount++;
+    end;
+endmodule
+```
+
+### Explanation
+
+Simulator event ordering between concurrent action blocks is undefined, so
+observed behavior is simulator-dependent.
+While assertions with side-effects may appear to work on a single-threaded
+simulator, they may interact in unexpected ways on a multi-threaded simulator.
+On encountering side-effect code in action blocks, a simulator can either
+implement inter-thread locking (with a hit to performance) or allow a
+race-condition to occur, neither of which are desirable.
+
+Specifically, action blocks should not contain blocking assignments:
+- Blocking assignment operator, e.g. `foo = 123;`
+- Increment/decrement operators, e.g. `foo++;`, `foo--;`.
+- Sequential IO, e.g. `$display();`, `$write();`.
+  The full list of IO system tasks and system functions is given on page 624 of
+  IEEE1800-2017.
+
+See also:
+  - **non_blocking_assignment_in_always_comb** - Useful companion rule.
+  - **blocking_assignment_in_always_ff** - Useful companion rule.
+
+The most relevant clauses of IEEE1800-2017 are:
+  - 15.5.4 Event sequencing: wait\_order()
+  - 16 Assertions
+  - 21 Input/output system tasks and system functions
+
+
+---
 ## `blocking_assignment_in_always_ff`
 
 ### Hint

--- a/md/explanation-action_block_with_side_effect.md
+++ b/md/explanation-action_block_with_side_effect.md
@@ -1,0 +1,23 @@
+Simulator event ordering between concurrent action blocks is undefined, so
+observed behavior is simulator-dependent.
+While assertions with side-effects may appear to work on a single-threaded
+simulator, they may interact in unexpected ways on a multi-threaded simulator.
+On encountering side-effect code in action blocks, a simulator can either
+implement inter-thread locking (with a hit to performance) or allow a
+race-condition to occur, neither of which are desirable.
+
+Specifically, action blocks should not contain blocking assignments:
+- Blocking assignment operator, e.g. `foo = 123;`
+- Increment/decrement operators, e.g. `foo++;`, `foo--;`.
+- Sequential IO, e.g. `$display();`, `$write();`.
+  The full list of IO system tasks and system functions is given on page 624 of
+  IEEE1800-2017.
+
+See also:
+  - **non_blocking_assignment_in_always_comb** - Useful companion rule.
+  - **blocking_assignment_in_always_ff** - Useful companion rule.
+
+The most relevant clauses of IEEE1800-2017 are:
+  - 15.5.4 Event sequencing: wait\_order()
+  - 16 Assertions
+  - 21 Input/output system tasks and system functions

--- a/src/rules/action_block_with_side_effect.rs
+++ b/src/rules/action_block_with_side_effect.rs
@@ -1,0 +1,107 @@
+use crate::config::ConfigOption;
+use crate::linter::{Rule, RuleResult};
+use regex::Regex;
+use sv_parser::{unwrap_locate, unwrap_node, NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct ActionBlockWithSideEffect {
+    re: Option<Regex>,
+}
+
+impl Rule for ActionBlockWithSideEffect {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> RuleResult {
+        if self.re.is_none() {
+            let io_tasks =
+                [ "[f]?display[bho]?" // {{{
+                , "[f]?strobe[bho]?"
+                , "[sf]?write[bho]?"
+                , "[f]?monitor[bho]?"
+                , "monitoroff"
+                , "monitoron"
+                , "fclose"
+                , "fopen"
+                , "[sf]scanf"
+                , "fread"
+                , "fseek"
+                , "fflush"
+                , "feof"
+                , "fget[sc]"
+                , "ungetc"
+                , "rewind"
+                , "ftell"
+                , "ferror"
+                , "readmem[bh]"
+                , "writemem[bh]"
+                , "dumpfile"
+                , "dumpvars"
+                , "dumpoff"
+                , "dumpon"
+                , "dumpall"
+                , "dumplimit"
+                , "dumpflush"
+                , "dumpports"
+                , "dumpportsoff"
+                , "dumpportson"
+                , "dumpportsall"
+                , "dumpportsflush"
+                , "dumpportslimit"
+                ].join("|"); // }}}
+
+            self.re = Some(Regex::new(format!("^\\$({})$", io_tasks).as_str()).unwrap());
+        }
+
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return RuleResult::Pass;
+            }
+        };
+
+        match node {
+            RefNode::ActionBlock(x) => {
+                let loc = if let Some(y) = unwrap_node!(*x, BlockingAssignment) {
+                    Some(unwrap_locate!(y).unwrap())
+                } else if let Some(y) = unwrap_node!(*x, VariableDeclAssignment) {
+                    Some(unwrap_locate!(y).unwrap())
+                } else if let Some(y) = unwrap_node!(*x, IncOrDecExpression) {
+                    Some(unwrap_locate!(y).unwrap())
+                } else if let Some(y) = unwrap_node!(*x, SystemTfIdentifier) {
+                    let re = self.re.as_ref().unwrap();
+                    let l = unwrap_locate!(y).unwrap();
+                    let t = syntax_tree.get_str(l).unwrap();
+                    if re.is_match(&t) {
+                        Some(l)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                if let Some(loc) = loc {
+                    RuleResult::FailLocate(*loc)
+                } else {
+                    RuleResult::Pass
+                }
+            }
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("action_block_with_side_effect")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("Do not specify side effects within `assert` or `wait_order` action blocks.")
+    }
+
+    fn reason(&self) -> String {
+        String::from("Side effects may cause undefined event ordering.")
+    }
+}

--- a/testcases/fail/action_block_with_side_effect.sv
+++ b/testcases/fail/action_block_with_side_effect.sv
@@ -1,0 +1,25 @@
+module M;
+  always @(posedge clk)
+    assert (A) // These are legal, but potentially confusing.
+    else begin
+      $display("A should be high."); // Write to STDOUT.
+
+      // Update global variable.
+      errorId = 5; // What value if multiple immediate assertions fail?
+      errorCount++; // Hopefully simulator blocks between processes.
+    end
+
+  // In what order do these action blocks occur?
+  asrt_b1: assert property (@(posedge clk) B1)
+    else begin
+      $display("B1 should be high.");
+      errorId = 1;
+      errorCount++;
+    end;
+  asrt_b2: assert property (@(posedge clk) B2)
+    else begin
+      $display("B2 should be high.");
+      errorId = 2;
+      errorCount++;
+    end;
+endmodule

--- a/testcases/pass/action_block_with_side_effect.sv
+++ b/testcases/pass/action_block_with_side_effect.sv
@@ -1,0 +1,11 @@
+module M;
+  always @(posedge clk)
+    assert (A)
+      else $error("A should be high.");
+
+  // Simulator must report line number, label, and time on each violation.
+  asrt_b1: assert property (@(posedge clk) B1)
+    else $error("B1 should be high.");
+  asrt_b2: assert property (@(posedge clk) B2)
+    else $error("B2 should be high.");
+endmodule


### PR DESCRIPTION
As per #181.

Detect non-sensical cases like this:

```systemverilog
assert (foo) begin: pass_action_block
  $display("IO says it passed"); // Usually replace with $info.
end: pass_action_block
else begin: fail_action_block
  $display("IO says it failed"); // Usually replace with $error, or perhaps $fatal, $warning, $info.
  a++; // Undefined behaviour...
  b--; // ...but will probably work in single-threaded sim.
end: fail_action_block
```