### PR TITLE
Bugfix: Correct keyword regex used by `style_keyword_*`.

### DIFF
--- a/src/rules/style_keyword_0or1space.rs
+++ b/src/rules/style_keyword_0or1space.rs
@@ -25,7 +25,7 @@ impl Rule for StyleKeyword0Or1Space {
             - exactly 1space, then identifier or symbol
         */
         if self.re_split.is_none() {
-            self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
+            self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =

--- a/src/rules/style_keyword_0space.rs
+++ b/src/rules/style_keyword_0space.rs
@@ -24,7 +24,7 @@ impl Rule for StyleKeyword0Space {
             - nothing, immediately followed by a symbol
         */
         if self.re_split.is_none() {
-            self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
+            self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =

--- a/src/rules/style_keyword_1or2space.rs
+++ b/src/rules/style_keyword_1or2space.rs
@@ -25,7 +25,7 @@ impl Rule for StyleKeyword1Or2Space {
             - exactly 2space
         */
         if self.re_split.is_none() {
-            self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
+            self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =

--- a/src/rules/style_keyword_1space.rs
+++ b/src/rules/style_keyword_1space.rs
@@ -24,7 +24,7 @@ impl Rule for StyleKeyword1Space {
             - exactly 1space, then nothing
         */
         if self.re_split.is_none() {
-            self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
+            self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =

--- a/src/rules/style_keyword_construct.rs
+++ b/src/rules/style_keyword_construct.rs
@@ -26,7 +26,7 @@ impl Rule for StyleKeywordConstruct {
             - exactly 1space, then comment
         */
         if self.re_split.is_none() {
-            self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
+            self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =

--- a/src/rules/style_keyword_datatype.rs
+++ b/src/rules/style_keyword_datatype.rs
@@ -25,7 +25,7 @@ impl Rule for StyleKeywordDatatype {
             - exactly 1space, then identifier
         */
         if self.re_split.is_none() {
-            self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
+            self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =

--- a/src/rules/style_keyword_end.rs
+++ b/src/rules/style_keyword_end.rs
@@ -27,7 +27,7 @@ impl Rule for StyleKeywordEnd {
             - exactly 1space, then nothing
         */
         if self.re_split.is_none() {
-            self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
+            self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =

--- a/src/rules/style_keyword_maybelabel.rs
+++ b/src/rules/style_keyword_maybelabel.rs
@@ -26,7 +26,7 @@ impl Rule for StyleKeywordMaybelabel {
             - exactly 1space, then comment
         */
         if self.re_split.is_none() {
-            self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
+            self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =

--- a/src/rules/style_keyword_newline.rs
+++ b/src/rules/style_keyword_newline.rs
@@ -25,7 +25,7 @@ impl Rule for StyleKeywordNewline {
             - exactly 1space then a comment
         */
         if self.re_split.is_none() {
-            self.re_split = Some(Regex::new(r"(?P<kw>[a-z_01]+)(?P<succ>(?s:.)*)").unwrap());
+            self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =


### PR DESCRIPTION
- Reported in #211.
- New regex determined by looking at all the possibilities in sv-parser, instead of reading the LRM.
- Previous regex did not allow for characters $, ', B, X, or Z.
- I think only $ was causing a real issue, but keyword regex has been updated to include all characters to avoid confusing corner-cases later.