### PR TITLE
Bugfix/Improvement: Unittests for `--dump-filelist`, and fix two bugs.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ pub fn run_opt_config(opt: &Opt, config: Config) -> Result<bool, Error> {
         for filelist in &opt.filelist {
             let (mut f, mut i, d) = parse_filelist(filelist)?;
             if opt.dump_filelist {
-                dump_filelist(&filelist, &f, &i, &d);
+                dump_filelist(&mut printer, &filelist, &f, &i, &d);
             }
             files.append(&mut f);
             includes.append(&mut i);
@@ -223,7 +223,7 @@ pub fn run_opt_config(opt: &Opt, config: Config) -> Result<bool, Error> {
     };
 
     if opt.dump_filelist {
-        dump_filelist(&Path::new("."), &files, &includes, &defines);
+        dump_filelist(&mut printer, &Path::new("."), &files, &includes, &defines);
         return Ok(true);
     }
 
@@ -371,30 +371,31 @@ fn parse_filelist(
 }
 
 fn dump_filelist(
+    printer: &mut Printer,
     filename: &Path,
     files: &Vec<PathBuf>,
     incdirs: &Vec<PathBuf>,
     defines: &HashMap<String, Option<Define>>,
 ) -> () {
-    println!("{:?}:", filename);
+    printer.println(format!("{:?}:", filename).as_str());
 
-    println!("  files:");
+    printer.println(format!("  files:").as_str());
     for f in files {
-        println!("    - {:?}", f);
+        printer.println(format!("    - {:?}", f).as_str());
     }
 
-    println!("  incdirs:");
+    printer.println(format!("  incdirs:").as_str());
     for i in incdirs {
-        println!("    - {:?}", i);
+        printer.println(format!("    - {:?}", i).as_str());
     }
 
-    println!("  defines:");
+    printer.println(format!("  defines:").as_str());
     for (k, v) in defines {
         match v {
-            None => println!("    {:?}:", k),
+            None => printer.println(format!("    {:?}:", k).as_str()),
             Some(define) => match &define.text {
-                Some(definetext) => println!("    {:?}: {:?}", k, definetext.text),
-                None => println!("    {:?}:", k),
+                Some(definetext) => printer.println(format!("    {:?}: {:?}", k, definetext.text).as_str()),
+                None => printer.println(format!("    {:?}:", k).as_str()),
             },
         };
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use enquote;
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::{env, process};
 use sv_filelist_parser;
@@ -421,6 +421,25 @@ fn dump_filelist(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn testfile_path(s: &str) -> String {
+        format!(
+            "{}/testcases/{}",
+            env::var("CARGO_MANIFEST_DIR").unwrap(),
+            s
+        )
+    }
+
+    fn testfile_contents(s: &str) -> String {
+        let path: String = testfile_path(s);
+
+        let file = File::open(path).unwrap();
+        let mut buf_reader = BufReader::new(file);
+        let mut contents = String::new();
+        buf_reader.read_to_string(&mut contents).unwrap();
+
+        contents
+    }
 
     fn test(rulename: &str, filename: &str, pass_not_fail: bool, silent: bool, oneline: bool) {
         let s = format!("[rules]\n{} = true", rulename);

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ pub struct Opt {
 #[cfg_attr(tarpaulin, skip)]
 pub fn main() {
     let opt = Parser::parse();
-    let mut printer = Printer::new();
+    let mut printer = Printer::new(false);
     let exit_code = match run_opt(&mut printer, &opt) {
         Ok(pass) => {
             if pass {
@@ -432,7 +432,7 @@ mod tests {
         args.push(filename);
         let opt = Opt::parse_from(args.iter());
 
-        let mut printer = Printer::new();
+        let mut printer = Printer::new(false);
         let ret = run_opt_config(&mut printer, &opt, config.clone());
         assert_eq!(ret.unwrap(), pass_not_fail);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -462,5 +462,79 @@ mod tests {
 
     include!(concat!(env!("OUT_DIR"), "/test.rs"));
 
-    // TODO: Tests for --dump-filelist
+    #[test]
+    fn dump_filelist_1() {
+        let config: Config = toml::from_str("").unwrap();
+
+        // Files, not filelist.
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist");
+        let f_1 = Path::new("foo").join("bar").join("one.sv");
+        let f_2 = Path::new("foo").join("bar").join("two.sv");
+        args.push(f_1.to_str().unwrap());
+        args.push(f_2.to_str().unwrap());
+        let opt = Opt::parse_from(args.iter());
+
+        let mut printer = Printer::new(true);
+        let ret = run_opt_config(&mut printer, &opt, config.clone());
+        assert_eq!(ret.unwrap(), true);
+
+		let stdout = printer.read_to_string().unwrap();
+        assert_eq!(
+            stdout,
+            testfile_contents("expected/dump_filelist_1")
+        );
+    }
+
+    #[test]
+    fn dump_filelist_2() {
+        let config: Config = toml::from_str("").unwrap();
+
+        // Single flat filelist.
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist");
+        args.push("--filelist");
+        let f_1 = testfile_path("resources/child1.fl");
+        args.push(&f_1);
+        let opt = Opt::parse_from(args.iter());
+
+        let mut printer = Printer::new(true);
+        let ret = run_opt_config(&mut printer, &opt, config.clone());
+        assert_eq!(ret.unwrap(), true);
+
+		let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+		let stdout = printer.read_to_string().unwrap()
+			.replace(cargo_manifest_dir.as_str(), "$CARGO_MANIFEST_DIR");
+        assert_eq!(
+            stdout,
+            testfile_contents("expected/dump_filelist_2")
+        );
+    }
+
+    #[test]
+    fn dump_filelist_3() {
+        let config: Config = toml::from_str("").unwrap();
+
+        // Single non-flat filelist.
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist");
+        args.push("--filelist");
+        let f_1 = testfile_path("resources/parent1.fl");
+        args.push(&f_1);
+        let opt = Opt::parse_from(args.iter());
+
+        let mut printer = Printer::new(true);
+        let ret = run_opt_config(&mut printer, &opt, config.clone());
+        assert_eq!(ret.unwrap(), true);
+
+		let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+		let stdout = printer.read_to_string().unwrap()
+			.replace(cargo_manifest_dir.as_str(), "$CARGO_MANIFEST_DIR");
+        assert_eq!(
+            stdout,
+            testfile_contents("expected/dump_filelist_3")
+        );
+    }
+
+    // TODO: Multiple filelists.
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ pub fn run_opt(opt: &Opt) -> Result<bool, Error> {
 
         ret
     } else {
-        if !opt.silent {
+        if !opt.silent && !opt.dump_filelist && !opt.preprocess_only {
             println!(
                 "Config file '{}' is not found. Enable all rules",
                 opt.config.to_string_lossy()

--- a/src/main.rs
+++ b/src/main.rs
@@ -401,7 +401,11 @@ fn dump_filelist(
     }
 
     printer.println(&format!("  defines:"))?;
-    for (k, v) in defines {
+	let mut keys: Vec<&String> = defines.keys().collect();
+	keys.sort_unstable();
+    for k in keys {
+		let v = defines.get(k).unwrap();
+
         match v {
             None => printer.println(&format!("    {:?}:", k)),
             Some(define) => match &define.text {

--- a/src/main.rs
+++ b/src/main.rs
@@ -463,7 +463,7 @@ mod tests {
     include!(concat!(env!("OUT_DIR"), "/test.rs"));
 
     #[test]
-    fn dump_filelist_1() {
+    fn dump_filelist_1() { // {{{
         let config: Config = toml::from_str("").unwrap();
 
         // Files, not filelist.
@@ -484,10 +484,10 @@ mod tests {
             stdout,
             testfile_contents("expected/dump_filelist_1")
         );
-    }
+    } // }}}
 
     #[test]
-    fn dump_filelist_2() {
+    fn dump_filelist_2() { // {{{
         let config: Config = toml::from_str("").unwrap();
 
         // Single flat filelist.
@@ -509,10 +509,10 @@ mod tests {
             stdout,
             testfile_contents("expected/dump_filelist_2")
         );
-    }
+    } // }}}
 
     #[test]
-    fn dump_filelist_3() {
+    fn dump_filelist_3() { // {{{
         let config: Config = toml::from_str("").unwrap();
 
         // Single non-flat filelist.
@@ -534,7 +534,60 @@ mod tests {
             stdout,
             testfile_contents("expected/dump_filelist_3")
         );
-    }
+    } // }}}
 
-    // TODO: Multiple filelists.
+    #[test]
+    fn dump_filelist_4() { // {{{
+        let config: Config = toml::from_str("").unwrap();
+
+        // Muliple filelists.
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist");
+        args.push("--filelist");
+        let f_1 = testfile_path("resources/child1.fl");
+        args.push(&f_1);
+        args.push("--filelist");
+        let f_2 = testfile_path("resources/child2.fl");
+        args.push(&f_2);
+        let opt = Opt::parse_from(args.iter());
+
+        let mut printer = Printer::new(true);
+        let ret = run_opt_config(&mut printer, &opt, config.clone());
+        assert_eq!(ret.unwrap(), true);
+
+        let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let stdout = printer.read_to_string().unwrap()
+            .replace(cargo_manifest_dir.as_str(), "$CARGO_MANIFEST_DIR");
+        println!("{}", stdout);
+        assert_eq!(
+            stdout,
+            testfile_contents("expected/dump_filelist_4")
+        );
+    } // }}}
+
+    #[test]
+    fn dump_filelist_5() { // {{{
+        let config: Config = toml::from_str("").unwrap();
+
+        // Single deeper filelist.
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist");
+        args.push("--filelist");
+        let f_1 = testfile_path("resources/grandparent1.fl");
+        args.push(&f_1);
+        let opt = Opt::parse_from(args.iter());
+
+        let mut printer = Printer::new(true);
+        let ret = run_opt_config(&mut printer, &opt, config.clone());
+        assert_eq!(ret.unwrap(), true);
+
+        let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let stdout = printer.read_to_string().unwrap()
+            .replace(cargo_manifest_dir.as_str(), "$CARGO_MANIFEST_DIR");
+        println!("{}", stdout);
+        assert_eq!(
+            stdout,
+            testfile_contents("expected/dump_filelist_5")
+        );
+    } // }}}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,15 +216,16 @@ pub fn run_opt_config(opt: &Opt, config: Config) -> Result<bool, Error> {
                 defines.insert(k, v);
             }
         }
-        if opt.dump_filelist {
-            dump_filelist(&Path::new("."), &files, &includes, &defines);
-            return Ok(true);
-        }
 
         (files, includes)
     } else {
         (opt.files.clone(), opt.includes.clone())
     };
+
+    if opt.dump_filelist {
+        dump_filelist(&Path::new("."), &files, &includes, &defines);
+        return Ok(true);
+    }
 
     let mut all_pass = true;
 
@@ -422,4 +423,6 @@ mod tests {
     }
 
     include!(concat!(env!("OUT_DIR"), "/test.rs"));
+
+    // TODO: Tests for --dump-filelist
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -401,10 +401,10 @@ fn dump_filelist(
     }
 
     printer.println(&format!("  defines:"))?;
-	let mut keys: Vec<&String> = defines.keys().collect();
-	keys.sort_unstable();
+    let mut keys: Vec<&String> = defines.keys().collect();
+    keys.sort_unstable();
     for k in keys {
-		let v = defines.get(k).unwrap();
+        let v = defines.get(k).unwrap();
 
         match v {
             None => printer.println(&format!("    {:?}:", k)),
@@ -479,7 +479,7 @@ mod tests {
         let ret = run_opt_config(&mut printer, &opt, config.clone());
         assert_eq!(ret.unwrap(), true);
 
-		let stdout = printer.read_to_string().unwrap();
+        let stdout = printer.read_to_string().unwrap();
         assert_eq!(
             stdout,
             testfile_contents("expected/dump_filelist_1")
@@ -502,9 +502,9 @@ mod tests {
         let ret = run_opt_config(&mut printer, &opt, config.clone());
         assert_eq!(ret.unwrap(), true);
 
-		let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-		let stdout = printer.read_to_string().unwrap()
-			.replace(cargo_manifest_dir.as_str(), "$CARGO_MANIFEST_DIR");
+        let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let stdout = printer.read_to_string().unwrap()
+            .replace(cargo_manifest_dir.as_str(), "$CARGO_MANIFEST_DIR");
         assert_eq!(
             stdout,
             testfile_contents("expected/dump_filelist_2")
@@ -527,9 +527,9 @@ mod tests {
         let ret = run_opt_config(&mut printer, &opt, config.clone());
         assert_eq!(ret.unwrap(), true);
 
-		let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-		let stdout = printer.read_to_string().unwrap()
-			.replace(cargo_manifest_dir.as_str(), "$CARGO_MANIFEST_DIR");
+        let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let stdout = printer.read_to_string().unwrap()
+            .replace(cargo_manifest_dir.as_str(), "$CARGO_MANIFEST_DIR");
         assert_eq!(
             stdout,
             testfile_contents("expected/dump_filelist_3")

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -61,6 +61,13 @@ impl Printer {
         }
     }
 
+    pub fn read_to_string(&self) -> Option<String> {
+        match self.term {
+            TermCapture::Capturable(ref buf) => Some(String::from_utf8_lossy(buf).to_string()),
+            _ => None
+        }
+    }
+
     #[cfg_attr(tarpaulin, skip)]
     fn write(&mut self, dat: &str, color: Color) {
         match self.term {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -384,25 +384,25 @@ impl Printer {
     }
 
     #[cfg_attr(tarpaulin, skip)]
-    pub fn print_error(&mut self, error: &str) -> Result<(), Error> {
+    pub fn print_error(&mut self, msg: &str) -> Result<(), Error> {
         self.write("Error", Color::BrightRed);
-        self.write(&format!(": {}", error), Color::BrightWhite);
+        self.write(&format!(": {}", msg), Color::BrightWhite);
         self.write("\n", Color::Reset);
         Ok(())
     }
 
     #[cfg_attr(tarpaulin, skip)]
-    pub fn print_warning(&mut self, error: &str) -> Result<(), Error> {
+    pub fn print_warning(&mut self, msg: &str) -> Result<(), Error> {
         self.write("Warning", Color::BrightYellow);
-        self.write(&format!(": {}", error), Color::BrightWhite);
+        self.write(&format!(": {}", msg), Color::BrightWhite);
         self.write("\n", Color::Reset);
         Ok(())
     }
 
     #[cfg_attr(tarpaulin, skip)]
-    pub fn print_info(&mut self, error: &str) -> Result<(), Error> {
+    pub fn print_info(&mut self, msg: &str) -> Result<(), Error> {
         self.write("Info", Color::BrightGreen);
-        self.write(&format!(": {}", error), Color::BrightWhite);
+        self.write(&format!(": {}", msg), Color::BrightWhite);
         self.write("\n", Color::Reset);
         Ok(())
     }
@@ -420,8 +420,14 @@ impl Printer {
     }
 
     #[cfg_attr(tarpaulin, skip)]
-    pub fn println(&mut self, line: &str) -> Result<(), Error> {
-        self.write(line, Color::Reset);
+    pub fn print(&mut self, msg: &str) -> Result<(), Error> {
+        self.write(msg, Color::Reset);
+        Ok(())
+    }
+
+    #[cfg_attr(tarpaulin, skip)]
+    pub fn println(&mut self, msg: &str) -> Result<(), Error> {
+        self.write(msg, Color::Reset);
         self.write("\n", Color::Reset);
         Ok(())
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -419,6 +419,13 @@ impl Printer {
         Ok(())
     }
 
+    #[cfg_attr(tarpaulin, skip)]
+    pub fn println(&mut self, line: &str) -> Result<(), Error> {
+        self.write(line, Color::Reset);
+        self.write("\n", Color::Reset);
+        Ok(())
+    }
+
     //#[cfg_attr(tarpaulin, skip)]
     //fn print_summary(
     //    &mut self,

--- a/testcases/expected/dump_filelist_1
+++ b/testcases/expected/dump_filelist_1
@@ -1,0 +1,6 @@
+".":
+  files:
+    - "foo/bar/one.sv"
+    - "foo/bar/two.sv"
+  incdirs:
+  defines:

--- a/testcases/expected/dump_filelist_2
+++ b/testcases/expected/dump_filelist_2
@@ -1,0 +1,32 @@
+"$CARGO_MANIFEST_DIR/testcases/resources/child1.fl":
+  files:
+    - "child1_file1.sv"
+    - "child1_file2.sv"
+    - "child1_file1.sv"
+  incdirs:
+    - "relative/path/to/directory"
+    - "/absolute/path/to/directory"
+  defines:
+    "$(VAR1)": "var1"
+    "$VAR3": "var3"
+    "${VAR2}": "var2"
+    "A": "a"
+    "B": "b"
+    "C": "c"
+    "VAR4":
+".":
+  files:
+    - "child1_file1.sv"
+    - "child1_file2.sv"
+    - "child1_file1.sv"
+  incdirs:
+    - "relative/path/to/directory"
+    - "/absolute/path/to/directory"
+  defines:
+    "$(VAR1)": "var1"
+    "$VAR3": "var3"
+    "${VAR2}": "var2"
+    "A": "a"
+    "B": "b"
+    "C": "c"
+    "VAR4":

--- a/testcases/expected/dump_filelist_3
+++ b/testcases/expected/dump_filelist_3
@@ -1,0 +1,36 @@
+"$CARGO_MANIFEST_DIR/testcases/resources/parent1.fl":
+  files:
+    - "child1_file1.sv"
+    - "child1_file2.sv"
+    - "child1_file1.sv"
+    - "parent1_file1.sv"
+  incdirs:
+    - "relative/path/to/directory"
+    - "/absolute/path/to/directory"
+  defines:
+    "$(VAR1)": "var1"
+    "$VAR3": "var3"
+    "${VAR2}": "var2"
+    "A": "a"
+    "B": "b"
+    "C": "c"
+    "VAR4":
+    "a": "123"
+".":
+  files:
+    - "child1_file1.sv"
+    - "child1_file2.sv"
+    - "child1_file1.sv"
+    - "parent1_file1.sv"
+  incdirs:
+    - "relative/path/to/directory"
+    - "/absolute/path/to/directory"
+  defines:
+    "$(VAR1)": "var1"
+    "$VAR3": "var3"
+    "${VAR2}": "var2"
+    "A": "a"
+    "B": "b"
+    "C": "c"
+    "VAR4":
+    "a": "123"

--- a/testcases/expected/dump_filelist_4
+++ b/testcases/expected/dump_filelist_4
@@ -1,0 +1,38 @@
+"$CARGO_MANIFEST_DIR/testcases/resources/child1.fl":
+  files:
+    - "child1_file1.sv"
+    - "child1_file2.sv"
+    - "child1_file1.sv"
+  incdirs:
+    - "relative/path/to/directory"
+    - "/absolute/path/to/directory"
+  defines:
+    "$(VAR1)": "var1"
+    "$VAR3": "var3"
+    "${VAR2}": "var2"
+    "A": "a"
+    "B": "b"
+    "C": "c"
+    "VAR4":
+"$CARGO_MANIFEST_DIR/testcases/resources/child2.fl":
+  files:
+    - "child2_file1.sv"
+  incdirs:
+  defines:
+".":
+  files:
+    - "child1_file1.sv"
+    - "child1_file2.sv"
+    - "child1_file1.sv"
+    - "child2_file1.sv"
+  incdirs:
+    - "relative/path/to/directory"
+    - "/absolute/path/to/directory"
+  defines:
+    "$(VAR1)": "var1"
+    "$VAR3": "var3"
+    "${VAR2}": "var2"
+    "A": "a"
+    "B": "b"
+    "C": "c"
+    "VAR4":

--- a/testcases/expected/dump_filelist_5
+++ b/testcases/expected/dump_filelist_5
@@ -1,0 +1,42 @@
+"$CARGO_MANIFEST_DIR/testcases/resources/grandparent1.fl":
+  files:
+    - "child1_file1.sv"
+    - "child1_file2.sv"
+    - "child1_file1.sv"
+    - "parent1_file1.sv"
+    - "child2_file1.sv"
+    - "grandparent1_file1.sv"
+  incdirs:
+    - "relative/path/to/directory"
+    - "/absolute/path/to/directory"
+  defines:
+    "$(VAR1)": "var1"
+    "$VAR3": "var3"
+    "${VAR2}": "var2"
+    "A": "a"
+    "B": "b"
+    "C": "c"
+    "VAR4":
+    "a": "123"
+    "b": "456"
+".":
+  files:
+    - "child1_file1.sv"
+    - "child1_file2.sv"
+    - "child1_file1.sv"
+    - "parent1_file1.sv"
+    - "child2_file1.sv"
+    - "grandparent1_file1.sv"
+  incdirs:
+    - "relative/path/to/directory"
+    - "/absolute/path/to/directory"
+  defines:
+    "$(VAR1)": "var1"
+    "$VAR3": "var3"
+    "${VAR2}": "var2"
+    "A": "a"
+    "B": "b"
+    "C": "c"
+    "VAR4":
+    "a": "123"
+    "b": "456"

--- a/testcases/resources/child1.fl
+++ b/testcases/resources/child1.fl
@@ -1,0 +1,14 @@
+// Some comment
+# Another comment
++incdir+relative/path/to/directory
++incdir+/absolute/path/to/directory
++define+A=a+B=b+C=c
++define+$(VAR1)=var1
++define+${VAR2}=var2
++define+$VAR3=var3
++define+VAR4
+child1_file1.sv
+child1_file2.sv
+
+# Repeat a filename.
+child1_file1.sv

--- a/testcases/resources/child2.fl
+++ b/testcases/resources/child2.fl
@@ -1,0 +1,1 @@
+child2_file1.sv

--- a/testcases/resources/grandparent1.fl
+++ b/testcases/resources/grandparent1.fl
@@ -1,0 +1,4 @@
+-f testcases/resources/parent1.fl
+-f testcases/resources/child2.fl
+grandparent1_file1.sv
++define+b=456

--- a/testcases/resources/parent1.fl
+++ b/testcases/resources/parent1.fl
@@ -1,0 +1,3 @@
+-f testcases/resources/child1.fl
+parent1_file1.sv
++define+a=123


### PR DESCRIPTION
- Bug1: Output should be repeatable. Before this PR, defines were printed in random order.
- Bug2: Before this PR, `--dump-filelist` only printed the list of files if `--filelist` was also given.
  After this PR, the behavior is consistent between `svlint -f foo.f` and `svlint foo.sv`, i.e. the list
  of files being processed (and defines, incdirs) is printed without any SV parsing.
- Improvement: All printed output is now goes via `Printer`, instead of mix of `print`, `println`,
  `write`, and `Printer`.
  Support has been added to capture the output and use this in unittests.
- There are now 5 unittests for `--dump-filelist`.
- I intend to open future PRs with unittest for other flags.

