### PR TITLE
Improvement: Update mdgen and its workflow.

### DIFF
--- a/.github/workflows/mdgen.yml
+++ b/.github/workflows/mdgen.yml
@@ -6,13 +6,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Rust
-        uses: hecrj/setup-rust-action@v1
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Generate Markdown files
-        run: cargo run --bin=mdgen
-      - name: Commit generated files
-        uses: EndBug/add-and-commit@v9
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --bin=mdgen
+      - uses: EndBug/add-and-commit@v9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mdgen.yml
+++ b/.github/workflows/mdgen.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Generate Markdown files
-        run: cargo run --bin mdgen
+        run: cargo run --bin=mdgen
       - name: Commit generated files
         uses: EndBug/add-and-commit@v9
         env:

--- a/.github/workflows/mdgen.yml
+++ b/.github/workflows/mdgen.yml
@@ -1,33 +1,18 @@
-name: Update RULES.md
+name: Generate version-controlled Markdown
 
 on: [push, pull_request]
 
 jobs:
   build:
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        rust: [stable]
-
-    runs-on: ${{ matrix.os }}
-
+    runs-on: ubuntu-latest
     steps:
-    - name: Setup Rust
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: ${{ matrix.rust }}
-    - name: Checkout
-      uses: actions/checkout@v1
-    - name: Run mdgen
-      run: cargo run --bin mdgen > RULES.md
-    - name: Commit
-      uses: EndBug/add-and-commit@v2.1.0
-      with:
-        author_name: dalance
-        author_email: dalance@gmail.com
-        message: "Update RULES.md"
-        path: "./"
-        pattern: "RULES.md"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Rust
+        uses: hecrj/setup-rust-action@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Generate Markdown files
+        run: cargo run --bin mdgen
+      - name: Commit generated files
+        uses: EndBug/add-and-commit@v9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mdgen.yml
+++ b/.github/workflows/mdgen.yml
@@ -1,4 +1,4 @@
-name: Generate version-controlled Markdown
+name: Run mdgen
 
 on: [push, pull_request]
 
@@ -7,15 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin=mdgen
+      - uses: hecrj/setup-rust-action@v1
+      - run: cargo run --bin=mdgen
       - uses: EndBug/add-and-commit@v9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 readme = "README.md"
 description = "SystemVerilog linter"
 edition = "2018"
+default-run = "svlint"
 
 [package.metadata.release]
 pre-release-commit-message  = "Prepare to v{{version}}"

--- a/RULES.md
+++ b/RULES.md
@@ -8025,3 +8025,4 @@ The most relevant clauses of IEEE1800-2017 are:
 
 
 DO_REBUILD
+DO_REBUILD

--- a/RULES.md
+++ b/RULES.md
@@ -8024,4 +8024,3 @@ The most relevant clauses of IEEE1800-2017 are:
   - Not applicable.
 
 
-DO_REBUILD

--- a/RULES.md
+++ b/RULES.md
@@ -8024,3 +8024,4 @@ The most relevant clauses of IEEE1800-2017 are:
   - Not applicable.
 
 
+DO_REBUILD


### PR DESCRIPTION
- Use the `default-run` manifest key to allow `cargo run` (instead of `cargo run --bin=svlint`) which is a little easier for development.
- Write directly to `RULES.md` with `cargo run --bin=mdgen` (instead of `cargo run --bin=mdgen > RULES.md`).
  - Allow command to be run from anywhere in the repo, and slightly less typing.
  - This allows future work to write multiple files instead of only `RULES.md` (intended for future PR based on [rulesets-dev](https://github.com/DaveMcEwan/svlint/tree/rulesets-dev))
- Update workflow file for mdgen:
  - `actions/checkout@v1` -> `actions/checkout@v3`
  - `EndBug/add-and-commit@v2.1.0` -> `EndBug/add-and-commit@v9`