### PR TITLE
Improvement: Split testcase examples in documentation.

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -161,9 +161,8 @@ Do not specify side effects within `assert` or `wait_order` action blocks.
 
 Side effects may cause undefined event ordering.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always @(posedge clk)
     assert (A)
@@ -177,9 +176,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   always @(posedge clk)
     assert (A) // These are legal, but potentially confusing.
@@ -245,9 +243,8 @@ Do not use blocking assignments within `always_ff`.
 
 Blocking assignment in `always_ff` may cause undefined event ordering.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_ff @(posedge clk) q1 <= d; // Correct.
 
@@ -257,9 +254,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
 /* svlint off blocking_assignment_in_always_ff */
 always_ff @(posedge clk) q1 = d;   // Control comments avoid failure.
@@ -305,9 +301,8 @@ Use a `default` expression in `case` statements.
 
 Incomplete case may cause simulation/synthesis mismatch in `always_comb` and `function`.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb
     case (x)
@@ -322,9 +317,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   always_comb
     case (x)
@@ -376,17 +370,15 @@ Place `` `default_nettype none`` at the top of source code.
 
 Compiler directive `` `default_nettype none`` detects unintentional implicit wires.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 `default_nettype none
 module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
 endmodule
 ```
@@ -453,9 +445,8 @@ Specify an explicit `enum` base type.
 
 The default `enum` base type is `int` (32b, 2-state).
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   typedef enum int {
     i
@@ -463,9 +454,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   typedef enum
     { i
@@ -534,9 +524,8 @@ Add a `default` arm to the `case` statement.
 
 Fully-specified case clarifies design intent.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb
     case (x)
@@ -552,16 +541,18 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   always_comb
     case (x)
       1: a = 0; // Incompletely specified case implies memory.
     endcase
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   always_ff @(clk) begin
     case (x)
@@ -624,9 +615,8 @@ Add an `else` clause to the `if` statement.
 
 Fully-specified conditional clarifies design intent.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_ff @(clk)
     if (x) y <= 0;
@@ -638,14 +628,16 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   always_comb
     if (x) y = 0; // Incompletely specified condition implies memory.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   always_ff @(clk) begin
     if (a)
@@ -704,18 +696,16 @@ Rename `function` to something other than the name of a built-in function.
 
 Name clashes may cause confusion amongst tools and readers.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   function my_clog2;
   endfunction
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   function clog2;
   endfunction
@@ -752,9 +742,8 @@ Add the `automatic` lifetime specifier to function.
 
 Static lifetime of function items causes a simulation/synthesis mismatch.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   function automatic F;
   endfunction
@@ -822,9 +811,8 @@ module static M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   function F;
   endfunction
@@ -862,18 +850,16 @@ Declare `genvar` inside a loop generate construct.
 
 Minimized `genvar` scope makes code easier to read and review.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   for(genvar i=0; i < 10; i++) begin: a
   end
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   genvar i;
   for (i=0; i < 10; i++) begin
@@ -947,9 +933,8 @@ Declare `genvar` outside the loop generate construct.
 
 Some tools don't support `genvar` declarations inside loop generate constructs.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   genvar i;
   for (i=0; i < 10; i++) begin: a
@@ -957,9 +942,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   for (genvar i=0; i < 10; i++) begin: l_foo
   end: l_foo
@@ -1012,18 +996,16 @@ Specify `tri` datakind on `inout` ports.
 
 Explicit datakind of bi-directional ports should be consistent with input ports.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( inout tri a
   );
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( inout wire a
   );
@@ -1086,18 +1068,16 @@ Specify `var` datakind on `input` ports.
 
 Default datakind of input port is a tri-state net.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( input var a
   );
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( input logic a
   );
@@ -1161,9 +1141,8 @@ Specify the modport on the interface port.
 
 Without a modport, the interface port signals are all implictly `inout`.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( test_if.a a
   , interface.b b
@@ -1171,14 +1150,16 @@ module M
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M
   ( test_if a
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M
   ( interface b
   );
@@ -1228,18 +1209,16 @@ Use `always_comb`/`always_ff`/`always_latch` instead of `always`.
 
 General-purpose `always` cannot detect combinatorial/stateful (non-)blocking mistakes.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb begin
   end
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   always @* begin
   end
@@ -1308,16 +1287,14 @@ Remove `generate`/`endgenerate` keywords.
 
 Keywords `generate`/`endgenerate` do not change semantics of generate blocks.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   generate
   endgenerate
@@ -1361,9 +1338,8 @@ Remove `priority` keyword, perhaps replace with an assertion.
 
 Priority-case/if constructs may mismatch between simulation and synthesis.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   initial
     case (a)
@@ -1372,16 +1348,18 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   initial
     priority case (a)
       default: b = 1;
     endcase
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   initial
     priority if (a)
@@ -1445,9 +1423,8 @@ Remove `unique` keyword, perhaps replace with an assertion.
 
 Unique-case/if constructs may mismatch between simulation and synthesis.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   initial
     case (a)
@@ -1456,16 +1433,18 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   initial
     unique case (a)
       default: b = 1;
     endcase
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   initial
     unique if (a)
@@ -1539,9 +1518,8 @@ Remove `unique0` keyword, perhaps replace with an assertion.
 
 Unique0-case/if constructs may mismatch between simulation and synthesis.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   initial
     case (a)
@@ -1550,9 +1528,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   initial begin
     unique0 case (a)
@@ -1560,7 +1537,10 @@ module M;
     endcase
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   initial
     unique0 if (a)
@@ -1632,17 +1612,15 @@ Replace `wire` or `reg` keywords with `logic`, `tri` and/or `var`.
 
 Explicit datatype `logic` and/or datakind `var`/`tri` better describes intent.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   logic a;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   wire a;
   reg b;
@@ -1688,9 +1666,8 @@ Use `generate`/`endgenerate` keywords to define generate regions.
 
 Omitting `generate`/`endgenerate` keywords may cause issues with non-compliant tools.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   generate
 
@@ -1708,20 +1685,25 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M;
   if (a) begin
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 module M;
   case (a)
       default: a;
   endcase
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 module M;
   for (genvar i=0; i < 10; i++) begin
   end
@@ -1763,9 +1745,8 @@ Replace level-sensitive `always` with `always_comb`.
 
 Level-sensitive `always` cannot detect combinatorial/stateful (non-)blocking mistakes.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb begin
   end
@@ -1774,14 +1755,16 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   always @* begin // No sensitivity list.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   always @ (a or b) begin // No sensitivity to posedge, negedge, or edge.
   end
@@ -1841,17 +1824,15 @@ Provide an explicit type in `localparam` declaration.
 
 Explicit parameter types clarify intent and improve readability.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   localparam int A = 0;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   localparam L = 0;
 endmodule
@@ -1903,9 +1884,8 @@ Declare `localparam` with an explicit 2-state type.
 
 Design constants with Xs or Zs may cause simulation/synthesis mismatch.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   localparam byte     A = 8'b0;
   localparam shortint B = 16'b0;
@@ -1915,17 +1895,22 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M;
   localparam integer A = 32'b0; // 32b
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 module M;
   localparam logic B = 1'b0; // 1b
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 module M;
   localparam reg C = 1'b0; // 1b
 endmodule
@@ -2033,9 +2018,8 @@ Declare the loop variable within the loop, i.e. `for (int i`.
 
 Minimizing the variable's scope avoids common coding errors.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   initial
     for(int i=0; i < 10; i++) begin
@@ -2043,9 +2027,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   initial begin
     int i;
@@ -2082,9 +2065,8 @@ Add `begin`/`end` around multi-line `for` statement.
 
 Without `begin`/`end`, the loop statement may be confusing.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb begin
     for (int a=0; a < 10; a++) begin
@@ -2096,16 +2078,18 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   always_comb begin
     for (int i=0; i < 10; i++)
       a = 0;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   always_comb begin
     for (int i=0; i < 10; i++) a = 0; // This is okay.
@@ -2141,9 +2125,8 @@ Add `begin`/`end` around multi-line `if` statement.
 
 Without `begin`/`end`, the conditional statement may be confusing.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb begin
     if (a) begin
@@ -2171,15 +2154,17 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 5)
+```systemverilog
 module M;
   always_comb
     if (a)
       a = 0; // Missing begin/end.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 5)
+```systemverilog
 module M;
   always_comb
     if (a) begin
@@ -2187,7 +2172,10 @@ module M;
     end else if (a)
       a = 0; // Missing begin/end.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 5)
+```systemverilog
 module M;
   always_comb
     if (a) begin
@@ -2197,14 +2185,20 @@ module M;
     end else
       a = 0; // Missing begin/end.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (4 of 5)
+```systemverilog
 module M;
   always_comb begin
     if (a)
       a = 0; // Missing begin/end.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (5 of 5)
+```systemverilog
 module M;
   always_comb begin
     if (a) a = 0; // This conditional statement is okay.
@@ -2242,18 +2236,23 @@ Declare `module` header in ANSI style.
 
 Non-ANSI module headers are visually noisy and error-prone.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 3)
+```systemverilog
 module M      // An ANSI module has ports declared in the module header.
   ( input  a
   , output b
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 3)
+```systemverilog
 module M;     // A module with no ports is also ANSI.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (3 of 3)
+```systemverilog
 module M      // Declaring ports in the header with default direction (inout)
   ( a         // also specifies an ANSI module.
   , b
@@ -2261,9 +2260,8 @@ module M      // Declaring ports in the header with default direction (inout)
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( a
   , b
@@ -2306,18 +2304,16 @@ Remove non-blocking assignment in `always_comb`.
 
 Scheduling between blocking and non-blocking assignments is non-deterministic.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb
     x = 0;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   always_comb
     x <= 0;
@@ -2359,18 +2355,16 @@ Specify `var` datakind on `output` ports.
 
 Explicit datakind of output ports should be consistent with input ports.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( output var logic a
   );
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( output logic a
   );
@@ -2435,28 +2429,32 @@ Specify `parameter` with an explicit default value.
 
 Default values are required by some tools and clarify intent.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   #(parameter int P = 0
   ) ();
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M
   #(parameter int P // Type is specified (good), but default value isn't (bad).
   ) ();
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 module M
   #(parameter Q // Neither type or default value are specified (very bad).
   ) ();
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 module M
   #(parameter int P = 0
   , R // Legal, but even less clear about the author's intention.
@@ -2515,23 +2513,24 @@ Provide an explicit type in `parameter` declaration.
 
 Explicit parameter types clarify intent and improve readability.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   #(parameter int a = 0
   ) ();
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M
   #(parameter a = 0
   ) ();
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M
   #(parameter a = int'(0)
   ) ();
@@ -2584,9 +2583,8 @@ Replace `parameter` keyword with `localparam`.
 
 In a generate block, `localparam` properly describes the non-overridable semantics.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   for (genvar i=0; i < 5; i++) begin
     localparam int P1 = 1;
@@ -2609,9 +2607,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   for (genvar i=0; i < 5; i++) begin
     parameter int P1 = 1;
@@ -2660,17 +2657,15 @@ Replace `parameter` keyword with `localparam`.
 
 In a package, `localparam` properly describes the non-overridable semantics.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package P;
   localparam int A = 1;
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package P;
   parameter int A = 1;
 endpackage
@@ -2702,9 +2697,8 @@ Declare `parameter` with an explicit 2-state type.
 
 Design constants with Xs or Zs may cause simulation/synthesis mismatch.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   #(parameter byte     A = 8'b0
   , parameter shortint B = 16'b0
@@ -2715,19 +2709,24 @@ module M
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M
   #(parameter integer A = 32'b0
   ) ();
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 module M
   #(parameter logic B = 1'b0
   ) ();
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 module M
   #(parameter reg C = 1'b0
   , logic         Z = 1'b0 // TODO: Z isn't caught.
@@ -2765,9 +2764,8 @@ Keywords `begin` and `end` are forbidden within `always_comb`.
 
 Sequential blocks within `always_comb` introduce sequential dependencies.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb
     a = b;
@@ -2787,22 +2785,27 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 4)
+```systemverilog
 module M;
   always_comb begin
     a = z;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 4)
+```systemverilog
 module M;
   always_comb
     if (bar) begin
       b = z;
     end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 4)
+```systemverilog
 module M;
   always_comb
     if (bar) c = z;
@@ -2810,7 +2813,10 @@ module M;
       c = z;
     end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (4 of 4)
+```systemverilog
 module M;
   always_comb
     case (bar)
@@ -2883,9 +2889,8 @@ Keywords `begin` and `end` are forbidden within `always_ff`.
 
 Sequential blocks within `always_ff` may encourage overly-complex code.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_ff @(posedge clk)
     q <= d;
@@ -2906,22 +2911,27 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 4)
+```systemverilog
 module M;
   always_ff @(posedge clk) begin
     a <= z;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 4)
+```systemverilog
 module M;
   always_ff @(posedge clk)
     if (x) begin
       a <= z;
     end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 4)
+```systemverilog
 module M;
   always_ff @(posedge clk)
     if (x) a <= z;
@@ -2929,7 +2939,10 @@ module M;
       a <= z;
     end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (4 of 4)
+```systemverilog
 module M;
   always_ff @(posedge clk)
     case (x)
@@ -3053,9 +3066,8 @@ Keywords `begin` and `end` are forbidden within `always_latch`.
 
 Sequential blocks within `always_latch` may encourage overly-complex code.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_latch
     if (foo) a <= b;
@@ -3073,22 +3085,27 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 4)
+```systemverilog
 module M;
   always_latch begin
     a <= z;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 4)
+```systemverilog
 module M;
   always_latch
     if (x) begin
       a <= z;
     end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 4)
+```systemverilog
 module M;
   always_latch
     if (x) a <= z;
@@ -3096,7 +3113,10 @@ module M;
       a <= z;
     end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (4 of 4)
+```systemverilog
 module M;
   always_latch
     case (x)
@@ -3210,9 +3230,8 @@ Use a label with prefix "l_" on conditional generate block.
 
 Unnamed generate blocks imply unintuitive hierarchical paths.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module A;
   generate case (2'd3)
     2'd1:     begin: l_nondefault wire c = 1'b0; end
@@ -3221,9 +3240,8 @@ module A;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 5)
+```systemverilog
 module M;
   case (2'd0)             // No begin/end delimiters.
     2'd1:
@@ -3232,7 +3250,10 @@ module M;
       logic a = 1'b0;
   endcase
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 5)
+```systemverilog
 module M;
   case (2'd1)             // begin/end delimiters, but no label.
     2'd1: begin
@@ -3243,7 +3264,10 @@ module M;
     end
   endcase
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 5)
+```systemverilog
 module M;
   case (2'd2)             // With label, but no prefix.
     2'd1: begin: foo
@@ -3254,7 +3278,10 @@ module M;
     end                   // NOTE: Without optional label on end.
   endcase
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (4 of 5)
+```systemverilog
 module M;
   case (2'd4)             // Without default arm.
     2'd1: begin: foo
@@ -3262,7 +3289,10 @@ module M;
     end
   endcase
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (5 of 5)
+```systemverilog
 module M;
   case (2'd5)             // Without non-default arm.
     default: begin: bar
@@ -3320,29 +3350,33 @@ Use a label with prefix "l_" on loop generate block.
 
 Unnamed generate blocks imply unintuitive hierarchical paths.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   for(genvar i=0; i < 10; i++) begin: l_a
   end
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M;
   for (genvar i=0; i < 10; i++) // No begin/end delimeters.
     assign a[i] = i;
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 module M;
   for (genvar i=0; i < 10; i++) begin // begin/end delimiters, but no label.
     assign a[i] = i;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 module M;
   for (genvar i=0; i < 10; i++) begin: foo // With label, but no prefix.
     assign a[i] = i;
@@ -3398,9 +3432,8 @@ Use a label with prefix "l_" on conditional generate block.
 
 Unnamed generate blocks imply unintuitive hierarchical paths.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   if (a) begin: l_abc
   end else if (b) begin: l_def
@@ -3409,9 +3442,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 8)
+```systemverilog
 module M;
   if (x)                        // No begin/end delimeters.
     assign a = 0;               // if condition.
@@ -3421,7 +3453,10 @@ module M;
     assign a = 2;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 8)
+```systemverilog
 module M;
   if (x) begin: l_abc
     assign a = 0;
@@ -3441,7 +3476,10 @@ module M;
   end else                      // No begin/end delimeters.
     assign a = 2;               // else condition
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 8)
+```systemverilog
 module M;
   if (x) begin                  // begin/end delimiters, but no label.
     assign a = 0;               // if condition.
@@ -3451,7 +3489,10 @@ module M;
     assign a = 2;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (4 of 8)
+```systemverilog
 module M;
   if (x) begin: l_abc
     assign a = 0;
@@ -3461,7 +3502,10 @@ module M;
     assign a = 2;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (5 of 8)
+```systemverilog
 module M;
   if (x) begin: l_abc
     assign a = 0;
@@ -3471,7 +3515,10 @@ module M;
     assign a = 2;               // else condition
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (6 of 8)
+```systemverilog
 module M;
   if (x) begin: foo             // With label, but no prefix.
     assign a = 0;               // if condition.
@@ -3481,7 +3528,10 @@ module M;
     assign a = 2;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (7 of 8)
+```systemverilog
 module M;
   if (x) begin: l_abc
     assign a = 0;
@@ -3491,7 +3541,10 @@ module M;
     assign a = 2;
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (8 of 8)
+```systemverilog
 module M;
   if (x) begin: l_abc
     assign a = 0;
@@ -3551,16 +3604,14 @@ Begin `interface` name with lowerCamelCase.
 
 Naming convention simplifies audit.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 interface fooBar;
 endinterface
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 interface FooBar;
 endinterface
 ```
@@ -3596,16 +3647,14 @@ Begin `module` name with lowerCamelCase.
 
 Naming convention simplifies audit.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module fooBar;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module FooBar;
 endmodule
 ```
@@ -3641,16 +3690,14 @@ Begin `package` name with lowerCamelCase.
 
 Naming convention simplifies audit.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package fooBar;
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package FooBar;
 endpackage
 ```
@@ -3686,9 +3733,8 @@ Prefix `inout` port identifier with "b_".
 
 Port prefixes help readers to follow signals through modules.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( inout var b_foo
   , input var logic [FOO-1:0] b_bar
@@ -3696,19 +3742,24 @@ module M
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M
   ( inout var foo // `foo` is missing prefix.
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 module M
   ( inout var logic [A-1:0] bar // `bar` is missing prefix, not `A`.
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 module M
   ( inout var i_foo
   , inout var bar // `bar` is missing prefix.
@@ -3746,9 +3797,8 @@ Prefix `input` port identifier with "i_".
 
 Port prefixes help readers to follow signals through modules.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( input var i_foo
   , input var logic [FOO-1:0] i_bar
@@ -3756,9 +3806,8 @@ module M
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( input var foo
   , input var logic [FOO-1:0] bar
@@ -3795,17 +3844,15 @@ Prefix instance identifier with "u_".
 
 Naming convention helps investigation using hierarchical paths.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   I #() u_foo (a, b, c);
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   Foo #() foo (a, b, c);
 endmodule
@@ -3844,16 +3891,14 @@ Prefix `interface` identifier with "ifc_".
 
 Naming convention simplifies audit.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 interface ifc_withPrefix;
 endinterface
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 interface noPrefix;
 endinterface
 ```
@@ -3885,17 +3930,15 @@ Prefix `module` identifier with "mod_".
 
 Naming convention simplifies audit.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module mod_withPrefix; // Module identifier of declaration has prefix.
   I #(.A(1)) u_M (.a); // Module identifier of instance doesn't require prefix.
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module noPrefix; // Module identifier of declaration should have prefix.
 endmodule
 ```
@@ -3927,9 +3970,8 @@ Prefix `output` port identifier with "o_".
 
 Port prefixes help readers to follow signals through modules.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( output var o_foo
   , output var logic [FOO-1:0] o_bar
@@ -3937,9 +3979,8 @@ module M
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( output var foo
   , output var logic [FOO-1:0] bar
@@ -3976,16 +4017,14 @@ Prefix `package` identifier with "pkg_".
 
 Naming convention simplifies audit.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package pkg_withPrefix;
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package noPrefix;
 endpackage
 ```
@@ -4019,46 +4058,56 @@ Use an immediate assertion identifier not matching regex "^[^X](UNCONFIGURED|.*)
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 3)
+```systemverilog
 module M;
   initial begin
     Xfoo: // Identifier doesn't match default forbidden regex (X prefix).
       assert (p) else $error(); // Simple immmediate assertion statement.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 3)
+```systemverilog
 module M;
   initial begin
     Xfoo: // Identifier doesn't match default forbidden regex (X prefix).
       assert #0 (p) else $error(); // Deferred immmediate assertion statement.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (3 of 3)
+```systemverilog
 module M;
   Xfoo: // Identifier doesn't match default forbidden regex (X prefix).
     assert #0 (p) else $error(); // Deferred immmediate assertion item.
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M;
   initial begin
     foo: // Unconfigured forbidden regex matches (almost) anything.
       assert (p) else $error(); // Simple immmediate assertion statement.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 module M;
   initial begin
     foo: // Unconfigured forbidden regex matches (almost) anything.
       assert #0 (p) else $error(); // Deferred immmediate assertion statement.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 module M;
   foo: // Unconfigured forbidden regex matches (almost) anything.
     assert #0 (p) else $error(); // Deferred immmediate assertion item.
@@ -4085,14 +4134,16 @@ Use a concurrent assertion identifier not matching regex "^[^X](UNCONFIGURED|.*)
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 2)
+```systemverilog
 module M;
   Xfoo: // Identifier doesn't match default forbidden regex (X prefix).
     assert property (@(posedge c) p); // Concurrent assertion.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 2)
+```systemverilog
 module M;
   initial begin
     Xfoo: // Identifier doesn't match default forbidden regex (X prefix).
@@ -4101,14 +4152,16 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   foo: // Unconfigured forbidden regex matches (almost) anything.
     assert property (@(posedge c) p); // Concurrent assertion.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   initial begin
     foo: // Unconfigured forbidden regex matches (almost) anything.
@@ -4137,16 +4190,14 @@ Use a checker identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 checker Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
 endchecker
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 checker foo; // Unconfigured forbidden regex matches (almost) anything.
 endchecker
 ```
@@ -4171,16 +4222,14 @@ Use a class identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 class Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
 endclass
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 class foo; // Unconfigured forbidden regex matches (almost) anything.
 endclass
 ```
@@ -4205,18 +4254,16 @@ Use a function identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package P;
   function Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
   endfunction
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package P;
   function foo; // Unconfigured forbidden regex matches (almost) anything.
   endfunction
@@ -4244,9 +4291,8 @@ Use a generate block identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 3)
+```systemverilog
 module M;
   if (0) begin: Xfoo // Identifier doesn't match default forbidden regex (X prefix).
     assign a = 0;
@@ -4255,14 +4301,20 @@ module M;
     assign a = 1;
   end: Xbar
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 3)
+```systemverilog
 module M;
   // Identifier doesn't match default forbidden regex (X prefix).
   for (genvar i=0; i < 5; i++) begin: Xfoo
     assign b[i] = 0;
   end: Xfoo
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (3 of 3)
+```systemverilog
 module M;
   case (0)
     0: begin: Xfoo // Identifier doesn't match default forbidden regex (X prefix).
@@ -4278,9 +4330,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M;
   if (0) begin: foo // Unconfigured forbidden regex matches (almost) anything.
     assign a = 0;
@@ -4289,14 +4340,20 @@ module M;
     assign a = 1;
   end: bar
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 module M;
   // Unconfigured forbidden regex matches (almost) anything.
   for (genvar i=0; i < 5; i++) begin: foo
     assign b[i] = 0;
   end: foo
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 module M;
   case (0)
     0: begin: foo // Unconfigured forbidden regex matches (almost) anything.
@@ -4339,13 +4396,15 @@ Use a genvar identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 2)
+```systemverilog
 module M;
   genvar Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 2)
+```systemverilog
 module M;
   // Identifier doesn't match default forbidden regex (X prefix).
   for (genvar Xbar=0; Xbar < 5; Xbar++) begin
@@ -4353,13 +4412,15 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   genvar foo; // Unconfigured forbidden regex matches (almost) anything.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   // Unconfigured forbidden regex matches (almost) anything.
   for (genvar bar=0; bar < 5; bar++) begin
@@ -4387,18 +4448,16 @@ Use an instance identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   A #(
   ) Xfoo (); // Identifier doesn't match default forbidden regex (X prefix).
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   A #(
   ) foo (); // Unconfigured forbidden regex matches (almost) anything.
@@ -4430,16 +4489,14 @@ Use a interface identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 interface Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
 endinterface
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 interface foo; // Unconfigured forbidden regex matches (almost) anything.
 endinterface
 ```
@@ -4471,17 +4528,15 @@ Use a localparam identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package P;
   localparam Xfoo = 0; // Identifier doesn't match default forbidden regex (X prefix).
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package P;
   localparam foo = 0; // Unconfigured forbidden regex matches (almost) anything.
 endpackage
@@ -4512,9 +4567,8 @@ Use a modport identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 interface I;
   modport Xfoo // Identifier doesn't match default forbidden regex (X prefix).
   ( input i
@@ -4522,9 +4576,8 @@ interface I;
 endinterface
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 interface I;
   modport foo // Unconfigured forbidden regex matches (almost) anything.
   ( input i
@@ -4553,16 +4606,14 @@ Use a module identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module foo; // Unconfigured forbidden regex matches (almost) anything.
 endmodule
 ```
@@ -4597,9 +4648,8 @@ Use a module identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module Xfoo // Identifier doesn't match default forbidden regex (X prefix).
   ( a
   );
@@ -4607,9 +4657,8 @@ module Xfoo // Identifier doesn't match default forbidden regex (X prefix).
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module foo // Unconfigured forbidden regex matches (almost) anything.
   ( a
   );
@@ -4649,16 +4698,14 @@ Use a package identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package foo; // Unconfigured forbidden regex matches (almost) anything.
 endpackage
 ```
@@ -4690,18 +4737,16 @@ Use a parameter identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   #( Xfoo // Identifier doesn't match default forbidden regex (X prefix).
   ) ();
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   #( foo // Unconfigured forbidden regex matches (almost) anything.
   ) ();
@@ -4733,14 +4778,16 @@ Use a port identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 2)
+```systemverilog
 module M
   ( inout Xfoo // Identifier doesn't match default forbidden regex (X prefix).
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 2)
+```systemverilog
 module M_nonansi
   ( Xfoo
   );
@@ -4748,14 +4795,16 @@ module M_nonansi
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M
   ( inout foo // Unconfigured forbidden regex matches (almost) anything.
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M_nonansi
   ( foo
   );
@@ -4788,14 +4837,16 @@ Use a port identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 2)
+```systemverilog
 module M
   ( input Xfoo // Identifier doesn't match default forbidden regex (X prefix).
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 2)
+```systemverilog
 module M_nonansi
   ( Xfoo
   );
@@ -4803,14 +4854,16 @@ module M_nonansi
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M
   ( input foo // Unconfigured forbidden regex matches (almost) anything.
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M_nonansi
   ( foo
   );
@@ -4843,14 +4896,16 @@ Use a port identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 2)
+```systemverilog
 module M
   ( I Xfoo // Identifier doesn't match default forbidden regex (X prefix).
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 2)
+```systemverilog
 module M_nonansi
   ( Xfoo
   );
@@ -4858,14 +4913,16 @@ module M_nonansi
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M
   ( I.i foo // Unconfigured forbidden regex matches (almost) anything.
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M_nonansi
   ( foo
   );
@@ -4893,14 +4950,16 @@ Use a port identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 2)
+```systemverilog
 module M
   ( output Xfoo // Identifier doesn't match default forbidden regex (X prefix).
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 2)
+```systemverilog
 module M_nonansi
   ( Xfoo
   );
@@ -4908,14 +4967,16 @@ module M_nonansi
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M
   ( output foo // Unconfigured forbidden regex matches (almost) anything.
   );
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M_nonansi
   ( foo
   );
@@ -4948,18 +5009,16 @@ Use a port identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( ref Xfoo // Identifier doesn't match default forbidden regex (X prefix).
   );
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( ref foo // Unconfigured forbidden regex matches (almost) anything.
   );
@@ -4986,16 +5045,14 @@ Use a program identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 program Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
 endprogram
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 program foo; // Unconfigured forbidden regex matches (almost) anything.
 endprogram
 ```
@@ -5020,9 +5077,8 @@ Use a property identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   property Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
     @(posedge c) p; // Concurrent assertion.
@@ -5030,9 +5086,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   property foo; // Unconfigured forbidden regex matches (almost) anything.
     @(posedge c) p; // Concurrent assertion.
@@ -5060,9 +5115,8 @@ Use a sequence identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   sequence Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
     @(posedge c) a ##1 b
@@ -5070,9 +5124,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   sequence foo; // Unconfigured forbidden regex matches (almost) anything.
     @(posedge c) a ##1 b
@@ -5100,18 +5153,16 @@ Use a task identifier not matching regex "^[^X](UNCONFIGURED|.*)$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   task Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
   endtask
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   task foo; // Unconfigured forbidden regex matches (almost) anything.
   endtask
@@ -5138,17 +5189,15 @@ Use a class-scoped variable identifier not matching regex "^[^X](UNCONFIGURED|.*
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 class C;
   int Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
 endclass
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 class C;
   int foo; // Unconfigured forbidden regex matches (almost) anything.
 endclass
@@ -5174,9 +5223,8 @@ Use a method-scoped variable identifier not matching regex "^[^X](UNCONFIGURED|.
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 class C;
   function F;
     int Xfoo; // Identifier doesn't match default forbidden regex (X prefix).
@@ -5184,9 +5232,8 @@ class C;
 endclass
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 class C;
   function F;
     int foo; // Unconfigured forbidden regex matches (almost) anything.
@@ -5216,46 +5263,56 @@ Use an immediate assertion identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 3)
+```systemverilog
 module M;
   initial begin
     mn3: // Identifier matches default required regex (lowercase).
       assert (p) else $error(); // Simple immmediate assertion statement.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 3)
+```systemverilog
 module M;
   initial begin
     mn3: // Identifier matches default required regex (lowercase).
       assert #0 (p) else $error(); // Deferred immmediate assertion statement.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (3 of 3)
+```systemverilog
 module M;
   mn3: // Identifier matches default required regex (lowercase).
     assert #0 (p) else $error(); // Deferred immmediate assertion item.
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M;
   initial begin
     Mn3: // Identifier doesn't match default required regex (lowercase).
       assert (p) else $error(); // Simple immmediate assertion statement.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 module M;
   initial begin
     Mn3: // Identifier doesn't match default required regex (lowercase).
       assert #0 (p) else $error(); // Deferred immmediate assertion statement.
   end
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 module M;
   Mn3: // Identifier doesn't match default required regex (lowercase).
     assert #0 (p) else $error(); // Deferred immmediate assertion item.
@@ -5282,14 +5339,16 @@ Use a concurrent assertion identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 2)
+```systemverilog
 module M;
   mn3: // Identifier matches default required regex (lowercase).
     assert property (@(posedge c) p); // Concurrent assertion.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Pass Example (2 of 2)
+```systemverilog
 module M;
   initial begin
     mn3: // Identifier matches default required regex (lowercase).
@@ -5298,14 +5357,16 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 2)
+```systemverilog
 module M;
   Mn3: // Identifier doesn't match default required regex (lowercase).
     assert property (@(posedge c) p); // Concurrent assertion.
 endmodule
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 2)
+```systemverilog
 module M;
   initial begin
     Mn3: // Identifier doesn't match default required regex (lowercase).
@@ -5334,16 +5395,14 @@ Use a checker identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 checker mn3; // Identifier matches default required regex (lowercase).
 endchecker
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 checker Mn3; // Identifier doesn't match default required regex (lowercase).
 endchecker
 ```
@@ -5368,16 +5427,14 @@ Use a class identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 class mn3; // Identifier matches default required regex (lowercase).
 endclass
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 class Mn3; // Identifier doesn't match default required regex (lowercase).
 endclass
 ```
@@ -5402,18 +5459,16 @@ Use a function identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package P;
   function mn3; // Identifier matches default required regex (lowercase).
   endfunction
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package P;
   function Mn3; // Identifier doesn't match default required regex (lowercase).
   endfunction
@@ -5441,9 +5496,8 @@ Use a generate block identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   if (0) begin: mn3 // Identifier matches default required regex (lowercase).
     assign a = 0;
@@ -5471,9 +5525,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   if (0) begin: Mn3 // Identifier doesn't match default required regex (lowercase).
     assign a = 0;
@@ -5528,9 +5581,8 @@ Use a genvar identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   genvar mn3; // Identifier matches default required regex (lowercase).
 
@@ -5540,9 +5592,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   genvar Mn3; // Identifier doesn't match default required regex (lowercase).
 
@@ -5572,18 +5623,16 @@ Use an instance identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   A #(
   ) mn3 (); // Identifier matches default required regex (lowercase).
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   A #(
   ) Mn3 (); // Identifier doesn't match default required regex (lowercase).
@@ -5615,16 +5664,14 @@ Use a interface identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 interface mn3; // Identifier matches default required regex (lowercase).
 endinterface
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 interface Mn3; // Identifier doesn't match default required regex (lowercase).
 endinterface
 ```
@@ -5656,17 +5703,15 @@ Use a localparam identifier matching regex "^[A-Z]+[A-Z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package P;
   localparam MN3 = 0; // Identifier matches default required regex (uppercase).
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package P;
   localparam Mn3 = 0; // Identifier doesn't match default required regex (uppercase).
 endpackage
@@ -5697,9 +5742,8 @@ Use a modport identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 interface I;
   modport mn3 // Identifier matches default required regex (lowercase).
   ( input i
@@ -5707,9 +5751,8 @@ interface I;
 endinterface
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 interface I;
   modport Mn3 // Identifier doesn't match default required regex (lowercase).
   ( input i
@@ -5738,16 +5781,14 @@ Use a module identifier matching regex "^[a-z]+[a-zA-Z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module mN3; // Identifier matches default required regex (mixed-case).
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module Mn3; // Identifier doesn't match default required regex (mixed-case).
 endmodule
 ```
@@ -5782,9 +5823,8 @@ Use a module identifier matching regex "^[A-Z]+[A-Z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module MN3 // Identifier matches default required regex (uppercase).
   ( a
   );
@@ -5792,9 +5832,8 @@ module MN3 // Identifier matches default required regex (uppercase).
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module mn3 // Identifier doesn't match default required regex (uppercase).
   ( a
   );
@@ -5834,16 +5873,14 @@ Use a package identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package mn3; // Identifier matches default required regex (lowercase).
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package Mn3; // Identifier doesn't match default required regex (lowercase).
 endpackage
 ```
@@ -5875,18 +5912,16 @@ Use a parameter identifier matching regex "^[A-Z]+[A-Z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   #( MN3 // Identifier matches default required regex (uppercase).
   ) ();
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   #( Mn3 // Identifier doesn't match default required regex (uppercase).
   ) ();
@@ -5918,9 +5953,8 @@ Use a port identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( inout mn3 // Identifier matches default required regex (lowercase).
   );
@@ -5933,9 +5967,8 @@ module M_nonansi
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( inout Mn3 // Identifier doesn't match default required regex (lowercase).
   );
@@ -5973,9 +6006,8 @@ Use a port identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( input mn3 // Identifier matches default required regex (lowercase).
   );
@@ -5988,9 +6020,8 @@ module M_nonansi
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( input Mn3 // Identifier doesn't match default required regex (lowercase).
   );
@@ -6028,9 +6059,8 @@ Use a port identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( I.i mn3 // Identifier matches default required regex (lowercase).
   );
@@ -6043,9 +6073,8 @@ module M_nonansi
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( I.i Mn3 // Identifier doesn't match default required regex (lowercase).
   );
@@ -6078,9 +6107,8 @@ Use a port identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( output mn3 // Identifier matches default required regex (lowercase).
   );
@@ -6093,9 +6121,8 @@ module M_nonansi
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( output Mn3 // Identifier doesn't match default required regex (lowercase).
   );
@@ -6133,9 +6160,8 @@ Use a port identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( ref mn3 // Identifier matches default required regex (lowercase).
   );
@@ -6148,9 +6174,8 @@ module M_nonansi
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( ref Mn3 // Identifier doesn't match default required regex (lowercase).
   );
@@ -6183,16 +6208,14 @@ Use a program identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 program mn3; // Identifier matches default required regex (lowercase).
 endprogram
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 program Mn3; // Identifier doesn't match default required regex (lowercase).
 endprogram
 ```
@@ -6217,9 +6240,8 @@ Use a property identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   property mn3; // Identifier matches default required regex (lowercase).
     @(posedge c) p; // Concurrent assertion.
@@ -6227,9 +6249,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   property Mn3; // Identifier doesn't match default required regex (lowercase).
     @(posedge c) p; // Concurrent assertion.
@@ -6257,9 +6278,8 @@ Use a sequence identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   sequence mn3; // Identifier matches default required regex (lowercase).
     @(posedge c) a ##1 b
@@ -6267,9 +6287,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   sequence Mn3; // Identifier doesn't match default required regex (lowercase).
     @(posedge c) a ##1 b
@@ -6297,18 +6316,16 @@ Use a task identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   task mn3; // Identifier matches default required regex (lowercase).
   endtask
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   task Mn3; // Identifier doesn't match default required regex (lowercase).
   endtask
@@ -6335,17 +6352,15 @@ Use a class-scoped variable identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 class C;
   int mn3; // Identifier matches default required regex (lowercase).
 endclass
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 class C;
   int Mn3; // Identifier doesn't match default required regex (lowercase).
 endclass
@@ -6371,9 +6386,8 @@ Use a method-scoped variable identifier matching regex "^[a-z]+[a-z0-9_]*$".
 
 Identifiers must conform to the naming scheme.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 class C;
   function F;
     int mn3; // Identifier matches default required regex (lowercase).
@@ -6381,9 +6395,8 @@ class C;
 endclass
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 class C;
   function F;
     int Mn3; // Identifier doesn't match default required regex (lowercase).
@@ -6413,16 +6426,14 @@ Begin `interface` name with UpperCamelCase.
 
 Naming convention simplifies audit.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 interface FooBar;
 endinterface
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 interface fooBar;
 endinterface
 ```
@@ -6458,16 +6469,14 @@ Begin `module` name with UpperCamelCase.
 
 Naming convention simplifies audit.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module FooBar;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module fooBar;
 endmodule
 ```
@@ -6503,16 +6512,14 @@ Begin `package` name with UpperCamelCase.
 
 Naming convention simplifies audit.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 package FooBar;
 endpackage
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 package fooBar;
 endpackage
 ```
@@ -6555,9 +6562,8 @@ Follow each comma with a single space (comma-leading format).
 
 Consistent style enhances readability.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   #(bit FOO = 1 // comment
   , int BAR = 2 /* comment */
@@ -6584,9 +6590,8 @@ module M
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   #( bit FOO = 1 // Space after `#(` causes misalignment.
   , int BAR = 2
@@ -6734,9 +6739,8 @@ Follow each newline with an integer multiple of 2 spaces.
 
 Consistent indentation is essential for readability.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   if (a)
     a = 0;
@@ -6749,9 +6753,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
  if (a)
    a = 0;
@@ -6786,9 +6789,8 @@ Follow keyword with a symbol or exactly 1 space.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   function F;
     if (a)
@@ -6800,9 +6802,8 @@ endmodule
 
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   function F();
     if (a)
@@ -6844,9 +6845,8 @@ Remove all whitespace between keyword and following symbol.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb
     case (a)
@@ -6864,9 +6864,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   always_comb
     case (a)
@@ -6924,9 +6923,8 @@ Follow keyword with exactly 1 or 2 spaces.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M
   ( input a
   , inout b  // 1 space after `input` or `inout` keywords
@@ -6939,9 +6937,8 @@ module M
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M
   ( input   a
   , inout   b // multiple spaces after `input` or `inout` keywords
@@ -6992,9 +6989,8 @@ Follow keyword with exactly 1 space.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;                   // 1 space after `module`.
   for (i = 0; i < 5; i++)   // 1 space after `for`.
     assign foo = bar;       // 1 space after `assign`.
@@ -7006,9 +7002,8 @@ module M;                   // 1 space after `module`.
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module  M;                  // Multiple spaces after `module`.
   for(genvar i = 0; i < 5; i++)    // No spaces after `for`.
     assign  a = b;      // Multiple spaces after `assign`.
@@ -7226,9 +7221,8 @@ Follow keyword with a newline or exactly 1 space.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   always_comb a = b;  // 1 space after `always_comb`.
 
@@ -7246,9 +7240,8 @@ endmodule
 
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   always_comb   a = b;  // Multiple spaces after `always_comb`.
   initial     begin       // Multiple spaces after `initial`.
@@ -7324,9 +7317,8 @@ Follow datatype keyword with a symbol or exactly 1 space.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   localparam bit A = 0;   // 1 space after `bit`.
   localparam int B = 0;   // 1 space after `int`.
@@ -7336,9 +7328,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   localparam bit  A = 0;  // Multiple spaces after `bit`.
   localparam int
@@ -7408,9 +7399,8 @@ Follow keyword with a colon, newline, or exactly 1 space.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   initial begin
     if (foo) begin: l_foo
@@ -7428,9 +7418,8 @@ endmodule
 
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   initial begin
     if (foo) begin: l_foo
@@ -7498,9 +7487,8 @@ Follow keyword with a colon, newline, or exactly 1 space plus comment.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
 endmodule: M // colon immediately after `endmodule`
 package P;
@@ -7511,15 +7499,20 @@ endpackage // 1 space then comment after `endpackage`
 
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 3)
+```systemverilog
 module M;
 endmodule  : M // spaces immediately after `endmodule`
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (2 of 3)
+```systemverilog
 package P;
 endpackage  // multiple spaces then comment after `endpackage`
-////////////////////////////////////////////////////////////////////////////////
+```
+
+### Fail Example (3 of 3)
+```systemverilog
 interface I;
 endinterface interface J; // space instead of newline after `endinterface`
 endinterface
@@ -7591,9 +7584,8 @@ Follow keyword with a newline or exactly 1 space plus comment.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   generate
     case (foo)
@@ -7605,9 +7597,8 @@ endmodule
 
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   generate
     case (x)
@@ -7663,9 +7654,8 @@ Follow operator with a symbol, identifier, newline, or exactly 1 space.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   localparam bit [a-1:0] P1 = b; // No space around `-`.
 
@@ -7681,9 +7671,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   localparam int P2 = a  +  b; // Multiple spaces around `+`.
 
@@ -7732,9 +7721,8 @@ Follow operator with a exactly 1 space.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   localparam bit P1 = a && b; // Single space around `&&`.
 
@@ -7745,9 +7733,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   localparam bit P1 = a&&b; // No space around `&&`.
 
@@ -7804,9 +7791,8 @@ Follow operator with a newline or exactly 1 space.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   localparam int P1 = a | b; // Single space around `|`.
 
@@ -7820,9 +7806,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   localparam int P1 = a|b; // No space around `|`.
 
@@ -7875,9 +7860,8 @@ Remove all whitespace following the operator.
 
 Consistent use of whitespace enhances readability by reducing visual noise.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   localparam bit P1 = &{a, b}; // No space after `&`.
 
@@ -7886,9 +7870,8 @@ module M;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
   localparam bit P1 = & {a, b}; // No space after `&`.
 
@@ -7940,17 +7923,15 @@ Remove trailing whitespace.
 
 Trailing whitespace leads to unnecessary awkwardness with version control.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module        M;
 // End of line ^
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
                 
 // End of line ^
@@ -7990,17 +7971,15 @@ Replace tab characters with spaces.
 
 Tabs may cause misalignment depending on editor setup.
 
-### Pass Example
-
-```SystemVerilog
+### Pass Example (1 of 1)
+```systemverilog
 module M;
   logic a;
 endmodule
 ```
 
-### Fail Example
-
-```SystemVerilog
+### Fail Example (1 of 1)
+```systemverilog
 module M;
 	logic a;
 endmodule


### PR DESCRIPTION
In `RULES.md`, split the "Pass/Fail Example" code blocks into their respective testcases.
Examples are split the same way as in `build.rs` for the unittests, i.e. on lines with 80 consecutive `/`.

Apologies if this is too minor! This was developed on my rulesets-dev branch, but it isn't specific to that work.