### PR TITLE
Improvement: Nicer error message on file of invalid UTF-8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde                   = "1.0"
 serde_derive            = "1.0"
 serde_regex             = "1.1"
 clap                    = {version = "3.1.18", features = ["derive"]}
-sv-parser               = "0.12.2"
+sv-parser               = "0.12.3"
 term                    = "0.7"
 toml                    = "0.7"
 sv-filelist-parser      = "0.1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,11 +299,14 @@ fn print_parser_error(
                 printer.print_error(&format!("failed to include '{}'", x.to_string_lossy()))?;
             }
         }
+        SvParserError::DefineNoArgs(x) => {
+            printer.print_error(&format!("macro '{}' requires arguments", x))?;
+        }
         SvParserError::DefineArgNotFound(x) => {
-            printer.print_error(&format!("define argument '{}' is not found", x))?;
+            printer.print_error(&format!("macro argument '{}' is required", x))?;
         }
         SvParserError::DefineNotFound(x) => {
-            printer.print_error(&format!("define '{}' is not found", x))?;
+            printer.print_error(&format!("macro '{}' is not defined", x))?;
         }
         x => {
             printer.print_error(&format!("{}", x))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,6 +299,9 @@ fn print_parser_error(
                 printer.print_error(&format!("failed to include '{}'", x.to_string_lossy()))?;
             }
         }
+        SvParserError::ReadUtf8(path) => {
+            printer.print_error(&format!("file '{}' is not valid UTF-8", path.display()))?;
+        }
         SvParserError::DefineNoArgs(x) => {
             printer.print_error(&format!("macro '{}' requires arguments", x))?;
         }

--- a/src/rules/re_forbidden_assert.rs
+++ b/src/rules/re_forbidden_assert.rs
@@ -48,7 +48,7 @@ impl Rule for ReForbiddenAssert {
         };
 
         match node {
-            RefNode::DeferredImmediateAssetionItem(x) => {
+            RefNode::DeferredImmediateAssertionItem(x) => {
                 if let (Some(_id), _) = &x.nodes {
                     check_regex(false, unwrap_node!(*x, BlockIdentifier),
                                 &syntax_tree, &self.re.as_ref().unwrap())

--- a/src/rules/re_required_assert.rs
+++ b/src/rules/re_required_assert.rs
@@ -48,7 +48,7 @@ impl Rule for ReRequiredAssert {
         };
 
         match node {
-            RefNode::DeferredImmediateAssetionItem(x) => {
+            RefNode::DeferredImmediateAssertionItem(x) => {
                 if let (Some(_id), _) = &x.nodes {
                     check_regex(true, unwrap_node!(*x, BlockIdentifier),
                                 &syntax_tree, &self.re.as_ref().unwrap())


### PR DESCRIPTION
- Update sv-parser to 0.12.3
- Add support for `Error::ReadUtf8`.
- Rename `Assetion` -> `Assertion` (see https://github.com/dalance/sv-parser/pull/73).
- Add argument showing macro name for `DefineNoArgs`.
- Clarify wording of messages from `DefineNoArgs`, `DefineArgNotFound`, and `DefineNotFound`.
- Addresses comment about better UTF-8 error handling on #224.