### PR TITLE
Improvement: Don't emit control codes to STDOUT for non-colored output.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde                   = "1.0"
 serde_derive            = "1.0"
 serde_regex             = "1.1"
 clap                    = {version = "3.1.18", features = ["derive"]}
-sv-parser               = "0.12.3"
+sv-parser               = "0.13.0"
 term                    = "0.7"
 toml                    = "0.7"
 sv-filelist-parser      = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ regex                   = "1.5"
 serde                   = "1.0"
 serde_derive            = "1.0"
 serde_regex             = "1.1"
-clap                    = {version = "3.1.18", features = ["derive"]}
+clap                    = {version = "3.2", features = ["derive"]}
 sv-parser               = "0.13.0"
 term                    = "0.7"
 toml                    = "0.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,18 +499,18 @@ mod tests {
             // 1. CRLF -> LF
             let ret = contents.replace("\r\n", "\n");
 
-            // 2. "$CARGO_MANIFEST_DIR/foo/bar.baz" -> "$CARGO_MANIFEST_DIR\\foo\\bar.baz"
+            // 2. "$CARGO_MANIFEST_DIR/foo/bar.baz" -> "$CARGO_MANIFEST_DIR\foo\bar.baz"
             let expected_paths = Regex::new(r"\$CARGO_MANIFEST_DIR[a-zA-Z0-9_/]+").unwrap();
             let mut r = ret.clone();
             for cap in expected_paths.captures_iter(&ret) {
                 let expected_path = &cap[0];
-                let runtime_path = expected_path.replace("/", "\\\\");
+                let runtime_path = expected_path.replace("/", "\\");
                 r = r.replace(expected_path, &runtime_path);
             }
             let ret: String = r;
 
-            // 3. "$CARGO_MANIFEST_DIR\\foo\\bar.baz" -> "C:\\path\\svlint\\foo\\bar.baz"
-            let cargo_manifest_dir: String = cargo_manifest_dir.escape_default().to_string();
+            // 3. "$CARGO_MANIFEST_DIR\foo\bar.baz" -> "C:\path\svlint\foo\bar.baz"
+            let cargo_manifest_dir: String = cargo_manifest_dir.to_string();
             let ret = ret.replace("$CARGO_MANIFEST_DIR", cargo_manifest_dir.as_str());
 
             ret

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,14 @@ use svlint::printer::Printer;
 // -------------------------------------------------------------------------------------------------
 // Opt
 // -------------------------------------------------------------------------------------------------
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum DumpFilelistMode {
+    No,
+    Yaml,
+    Files,
+    Incdirs,
+    Defines,
+}
 
 #[derive(Debug, Parser)]
 #[clap(name = "svlint")]
@@ -89,8 +97,8 @@ pub struct Opt {
     pub example: bool,
 
     /// Print data from filelists
-    #[clap(long = "dump-filelist")]
-    pub dump_filelist: bool,
+    #[clap(value_enum, default_value = "no", long = "dump-filelist")]
+    pub dump_filelist: DumpFilelistMode,
 
     /// Print syntax trees
     #[clap(long = "dump-syntaxtree")]
@@ -158,7 +166,12 @@ pub fn run_opt(printer: &mut Printer, opt: &Opt) -> Result<bool, Error> {
 
         ret
     } else {
-        if !opt.silent && !opt.dump_filelist && !opt.preprocess_only {
+        let do_dump_filelist: bool = match opt.dump_filelist {
+            DumpFilelistMode::No => false,
+            _ => true,
+        };
+
+        if !opt.silent && !do_dump_filelist && !opt.preprocess_only {
             let msg = format!(
                 "Config file '{}' is not found. Enable all rules",
                 opt.config.to_string_lossy()
@@ -208,8 +221,8 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
 
         for filelist in &opt.filelist {
             let (mut f, mut i, d) = parse_filelist(filelist)?;
-            if opt.dump_filelist {
-                dump_filelist(printer, &filelist, &f, &i, &d)?;
+            if let DumpFilelistMode::Yaml = opt.dump_filelist {
+                dump_filelist(printer, &opt.dump_filelist, &filelist, &f, &i, &d)?;
             }
             files.append(&mut f);
             includes.append(&mut i);
@@ -223,9 +236,12 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
         (opt.files.clone(), opt.includes.clone())
     };
 
-    if opt.dump_filelist {
-        dump_filelist(printer, &Path::new("."), &files, &includes, &defines)?;
-        return Ok(true);
+    match opt.dump_filelist {
+        DumpFilelistMode::No => {}
+        _ => {
+            dump_filelist(printer, &opt.dump_filelist, &Path::new("."), &files, &includes, &defines)?;
+            return Ok(true);
+        }
     }
 
     let mut all_pass = true;
@@ -379,37 +395,68 @@ fn parse_filelist(
 
 fn dump_filelist(
     printer: &mut Printer,
+    mode: &DumpFilelistMode,
     filename: &Path,
     files: &Vec<PathBuf>,
     incdirs: &Vec<PathBuf>,
     defines: &HashMap<String, Option<Define>>,
 ) -> Result<(), Error> {
-    printer.println(&format!("{:?}:", filename))?;
+    match mode {
+        DumpFilelistMode::Yaml => {
+            printer.println(&format!("{:?}:", filename))?;
 
-    printer.println(&format!("  files:"))?;
-    for f in files {
-        printer.println(&format!("    - {:?}", f))?;
-    }
+            printer.println(&format!("  files:"))?;
+            for f in files {
+                printer.println(&format!("    - {:?}", f))?;
+            }
 
-    printer.println(&format!("  incdirs:"))?;
-    for i in incdirs {
-        printer.println(&format!("    - {:?}", i))?;
-    }
+            printer.println(&format!("  incdirs:"))?;
+            for i in incdirs {
+                printer.println(&format!("    - {:?}", i))?;
+            }
 
-    printer.println(&format!("  defines:"))?;
-    let mut keys: Vec<&String> = defines.keys().collect();
-    keys.sort_unstable();
-    for k in keys {
-        let v = defines.get(k).unwrap();
+            printer.println(&format!("  defines:"))?;
+            let mut keys: Vec<&String> = defines.keys().collect();
+            keys.sort_unstable();
+            for k in keys {
+                let v = defines.get(k).unwrap();
 
-        match v {
-            None => printer.println(&format!("    {:?}:", k)),
-            Some(define) => match &define.text {
-                Some(definetext) => printer.println(&format!("    {:?}: {:?}", k, definetext.text)),
-                None => printer.println(&format!("    {:?}:", k)),
-            },
-        }?;
-    }
+                match v {
+                    None => printer.println(&format!("    {:?}:", k)),
+                    Some(define) => match &define.text {
+                        Some(definetext) => printer.println(&format!("    {:?}: {:?}", k, definetext.text)),
+                        None => printer.println(&format!("    {:?}:", k)),
+                    },
+                }?;
+            }
+        }
+        DumpFilelistMode::Files => {
+            for f in files {
+                printer.println(&format!("{:?}", f))?;
+            }
+        }
+        DumpFilelistMode::Incdirs => {
+            for i in incdirs {
+                printer.println(&format!("{:?}", i))?;
+            }
+        }
+        DumpFilelistMode::Defines => {
+            let mut keys: Vec<&String> = defines.keys().collect();
+            keys.sort_unstable();
+            for k in keys {
+                let v = defines.get(k).unwrap();
+
+                match v {
+                    None => printer.println(&format!("{}", k)),
+                    Some(define) => match &define.text {
+                        Some(definetext) => printer.println(&format!("{}={}", k, definetext.text)),
+                        None => printer.println(&format!("{}=", k)),
+                    },
+                }?;
+            }
+        }
+        _ => {}
+    };
 
     Ok(())
 }
@@ -500,7 +547,7 @@ mod tests {
 
         // Files, not filelist.
         let mut args = vec!["svlint"];
-        args.push("--dump-filelist");
+        args.push("--dump-filelist=yaml");
         args.push("foo/bar/one.sv");
         args.push("foo/bar/two.sv");
         let opt = Opt::parse_from(args.iter());
@@ -520,7 +567,7 @@ mod tests {
 
         // Single flat filelist.
         let mut args = vec!["svlint"];
-        args.push("--dump-filelist");
+        args.push("--dump-filelist=yaml");
         args.push("--filelist");
         let f_1 = resources_path("child1.fl");
         args.push(&f_1);
@@ -541,7 +588,7 @@ mod tests {
 
         // Single non-flat filelist.
         let mut args = vec!["svlint"];
-        args.push("--dump-filelist");
+        args.push("--dump-filelist=yaml");
         args.push("--filelist");
         let f_1 = resources_path("parent1.fl");
         args.push(&f_1);
@@ -562,7 +609,7 @@ mod tests {
 
         // Muliple filelists.
         let mut args = vec!["svlint"];
-        args.push("--dump-filelist");
+        args.push("--dump-filelist=yaml");
         args.push("--filelist");
         let f_1 = resources_path("child1.fl");
         args.push(&f_1);
@@ -586,7 +633,7 @@ mod tests {
 
         // Single deeper filelist.
         let mut args = vec!["svlint"];
-        args.push("--dump-filelist");
+        args.push("--dump-filelist=yaml");
         args.push("--filelist");
         let f_1 = resources_path("grandparent1.fl");
         args.push(&f_1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -646,4 +646,67 @@ mod tests {
         let stdout = printer.read_to_string().unwrap();
         assert_eq!(stdout, expected_contents("dump_filelist_5"));
     } // }}}
+
+    #[test]
+    fn dump_filelist_6() {
+        // {{{
+        let config: Config = toml::from_str("").unwrap();
+
+        // Single deeper filelist.
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist=files");
+        args.push("--filelist");
+        let f_1 = resources_path("grandparent1.fl");
+        args.push(&f_1);
+        let opt = Opt::parse_from(args.iter());
+
+        let mut printer = Printer::new(true);
+        let ret = run_opt_config(&mut printer, &opt, config.clone());
+        assert_eq!(ret.unwrap(), true);
+
+        let stdout = printer.read_to_string().unwrap();
+        assert_eq!(stdout, expected_contents("dump_filelist_6"));
+    } // }}}
+
+    #[test]
+    fn dump_filelist_7() {
+        // {{{
+        let config: Config = toml::from_str("").unwrap();
+
+        // Single deeper filelist.
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist=incdirs");
+        args.push("--filelist");
+        let f_1 = resources_path("grandparent1.fl");
+        args.push(&f_1);
+        let opt = Opt::parse_from(args.iter());
+
+        let mut printer = Printer::new(true);
+        let ret = run_opt_config(&mut printer, &opt, config.clone());
+        assert_eq!(ret.unwrap(), true);
+
+        let stdout = printer.read_to_string().unwrap();
+        assert_eq!(stdout, expected_contents("dump_filelist_7"));
+    } // }}}
+
+    #[test]
+    fn dump_filelist_8() {
+        // {{{
+        let config: Config = toml::from_str("").unwrap();
+
+        // Single deeper filelist.
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist=defines");
+        args.push("--filelist");
+        let f_1 = resources_path("grandparent1.fl");
+        args.push(&f_1);
+        let opt = Opt::parse_from(args.iter());
+
+        let mut printer = Printer::new(true);
+        let ret = run_opt_config(&mut printer, &opt, config.clone());
+        assert_eq!(ret.unwrap(), true);
+
+        let stdout = printer.read_to_string().unwrap();
+        assert_eq!(stdout, expected_contents("dump_filelist_8"));
+    } // }}}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,16 +403,16 @@ fn dump_filelist(
 ) -> Result<(), Error> {
     match mode {
         DumpFilelistMode::Yaml => {
-            printer.println(&format!("{:?}:", filename))?;
+            printer.println(&format!("\"{}\":", filename.display()))?;
 
             printer.println(&format!("  files:"))?;
             for f in files {
-                printer.println(&format!("    - {:?}", f))?;
+                printer.println(&format!("    - \"{}\"", f.display()))?;
             }
 
             printer.println(&format!("  incdirs:"))?;
             for i in incdirs {
-                printer.println(&format!("    - {:?}", i))?;
+                printer.println(&format!("    - \"{}\"", i.display()))?;
             }
 
             printer.println(&format!("  defines:"))?;
@@ -422,22 +422,22 @@ fn dump_filelist(
                 let v = defines.get(k).unwrap();
 
                 match v {
-                    None => printer.println(&format!("    {:?}:", k)),
+                    None => printer.println(&format!("    \"{}\":", k)),
                     Some(define) => match &define.text {
-                        Some(definetext) => printer.println(&format!("    {:?}: {:?}", k, definetext.text)),
-                        None => printer.println(&format!("    {:?}:", k)),
+                        Some(definetext) => printer.println(&format!("    \"{}\": \"{}\"", k, definetext.text)),
+                        None => printer.println(&format!("    \"{}\":", k)),
                     },
                 }?;
             }
         }
         DumpFilelistMode::Files => {
             for f in files {
-                printer.println(&format!("{:?}", f))?;
+                printer.println(&format!("{}", f.display()))?;
             }
         }
         DumpFilelistMode::Incdirs => {
             for i in incdirs {
-                printer.println(&format!("{:?}", i))?;
+                printer.println(&format!("{}", i.display()))?;
             }
         }
         DumpFilelistMode::Defines => {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -471,45 +471,4 @@ impl Printer {
         self.write("\n", None);
         Ok(())
     }
-
-    //#[cfg_attr(tarpaulin, skip)]
-    //fn print_summary(
-    //    &mut self,
-    //    path_checked: &[(PathBuf, Vec<Checked>)],
-    //    _verbose: bool,
-    //    start_time: SystemTime,
-    //) -> Result<(), Error> {
-    //    self.write(
-    //        "- Summary ----------------------------------------------------------------------\n\n",
-    //        Color::BrightGreen,
-    //    );
-
-    //    let cnt_file = path_checked.len();
-    //    let cnt_checked = path_checked.iter().fold(0, |sum, (_, y)| sum + y.len());
-    //    let cnt_pass = path_checked.iter().fold(0, |sum, (_, y)| {
-    //        sum + y.iter().filter(|x| x.state == CheckedState::Pass).count()
-    //    });
-    //    let cnt_fail = path_checked.iter().fold(0, |sum, (_, y)| {
-    //        sum + y.iter().filter(|x| x.state == CheckedState::Fail).count()
-    //    });
-    //    let cnt_skip = path_checked.iter().fold(0, |sum, (_, y)| {
-    //        sum + y.iter().filter(|x| x.state == CheckedState::Skip).count()
-    //    });
-
-    //    self.write(&format!("  * Checked files : {}\n", cnt_file), Color::Reset);
-    //    self.write(
-    //        &format!(
-    //            "  * Checked points: {} ( Pass: {}, Fail: {}, Skip: {} )\n",
-    //            cnt_checked, cnt_pass, cnt_fail, cnt_skip
-    //        ),
-    //        Color::Reset,
-    //    );
-
-    //    let elapsed = start_time.elapsed()?;
-    //    let elapsed = elapsed.as_secs() as f64 + elapsed.subsec_micros() as f64 * 1e-6;
-    //    self.write(&format!("  * Elapsed time  : {}s\n", elapsed), Color::Reset);
-    //    self.write("\n", Color::Reset);
-
-    //    Ok(())
-    //}
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -69,56 +69,63 @@ impl Printer {
     }
 
     #[cfg_attr(tarpaulin, skip)]
-    fn write(&mut self, dat: &str, color: Color) {
+    fn write(&mut self, dat: &str, color: Option<Color>) {
         match self.term {
             TermCapture::Noncapturable(Some(ref mut term)) => {
-                let term_color = match color {
-                    Color::Black => color::BLACK,
-                    Color::Red => color::RED,
-                    Color::Green => color::GREEN,
-                    Color::Yellow => color::YELLOW,
-                    Color::Blue => color::BLUE,
-                    Color::Magenta => color::MAGENTA,
-                    Color::Cyan => color::CYAN,
-                    Color::White => color::WHITE,
-                    Color::BrightBlack => color::BRIGHT_BLACK,
-                    Color::BrightRed => color::BRIGHT_RED,
-                    Color::BrightGreen => color::BRIGHT_GREEN,
-                    Color::BrightYellow => color::BRIGHT_YELLOW,
-                    Color::BrightBlue => color::BRIGHT_BLUE,
-                    Color::BrightMagenta => color::BRIGHT_MAGENTA,
-                    Color::BrightCyan => color::BRIGHT_CYAN,
-                    Color::BrightWhite => color::BRIGHT_WHITE,
-                    Color::Reset => color::BLACK,
-                };
-                if color == Color::Reset {
-                    let _ = term.reset();
-                } else {
-                    let _ = term.fg(term_color);
+                if let Some(c) = color {
+                    if c == Color::Reset {
+                        let _ = term.reset();
+                    } else {
+                        let term_color = match c {
+                            Color::Black => color::BLACK,
+                            Color::Red => color::RED,
+                            Color::Green => color::GREEN,
+                            Color::Yellow => color::YELLOW,
+                            Color::Blue => color::BLUE,
+                            Color::Magenta => color::MAGENTA,
+                            Color::Cyan => color::CYAN,
+                            Color::White => color::WHITE,
+                            Color::BrightBlack => color::BRIGHT_BLACK,
+                            Color::BrightRed => color::BRIGHT_RED,
+                            Color::BrightGreen => color::BRIGHT_GREEN,
+                            Color::BrightYellow => color::BRIGHT_YELLOW,
+                            Color::BrightBlue => color::BRIGHT_BLUE,
+                            Color::BrightMagenta => color::BRIGHT_MAGENTA,
+                            Color::BrightCyan => color::BRIGHT_CYAN,
+                            Color::BrightWhite => color::BRIGHT_WHITE,
+                            Color::Reset => color::BLACK,
+                        };
+
+                        let _ = term.fg(term_color);
+                    }
                 }
                 let _ = write!(term, "{}", dat);
             }
             TermCapture::Noncapturable(None) => {
-                let colored = match color {
-                    Color::Black => dat.black(),
-                    Color::Red => dat.red(),
-                    Color::Green => dat.green(),
-                    Color::Yellow => dat.yellow(),
-                    Color::Blue => dat.blue(),
-                    Color::Magenta => dat.magenta(),
-                    Color::Cyan => dat.cyan(),
-                    Color::White => dat.white(),
-                    Color::BrightBlack => dat.bright_black(),
-                    Color::BrightRed => dat.bright_red(),
-                    Color::BrightGreen => dat.bright_green(),
-                    Color::BrightYellow => dat.bright_yellow(),
-                    Color::BrightBlue => dat.bright_blue(),
-                    Color::BrightMagenta => dat.bright_magenta(),
-                    Color::BrightCyan => dat.bright_cyan(),
-                    Color::BrightWhite => dat.bright_white(),
-                    Color::Reset => dat.clear(),
-                };
-                print!("{}", colored);
+                if let Some(c) = color {
+                    let colored = match c {
+                        Color::Black => dat.black(),
+                        Color::Red => dat.red(),
+                        Color::Green => dat.green(),
+                        Color::Yellow => dat.yellow(),
+                        Color::Blue => dat.blue(),
+                        Color::Magenta => dat.magenta(),
+                        Color::Cyan => dat.cyan(),
+                        Color::White => dat.white(),
+                        Color::BrightBlack => dat.bright_black(),
+                        Color::BrightRed => dat.bright_red(),
+                        Color::BrightGreen => dat.bright_green(),
+                        Color::BrightYellow => dat.bright_yellow(),
+                        Color::BrightBlue => dat.bright_blue(),
+                        Color::BrightMagenta => dat.bright_magenta(),
+                        Color::BrightCyan => dat.bright_cyan(),
+                        Color::BrightWhite => dat.bright_white(),
+                        Color::Reset => dat.clear(),
+                    };
+                    print!("{}", colored);
+                } else {
+                    print!("{}", dat);
+                }
             }
             TermCapture::Capturable(ref mut buf) => {
                 // NOTE: Capturable terminal is only for unit testability,
@@ -208,22 +215,22 @@ impl Printer {
         hint: Option<&str>,
     ) {
         Printer::with_pos(src, print_pos, |pos, column, row, next_crlf, _last_lf| {
-            self.write(header, Color::BrightRed);
+            self.write(header, Some(Color::BrightRed));
             self.write(
                 &format!("\t{}:{}:{}", path.to_string_lossy(), column, row),
-                Color::BrightBlue,
+                Some(Color::BrightBlue),
             );
             self.write(
                 &format!(
                     "\t{}",
                     String::from_utf8_lossy(&src.as_bytes()[pos..next_crlf])
                 ),
-                Color::White,
+                Some(Color::White),
             );
             if let Some(hint) = hint {
-                self.write(&format!("\thint: {}", hint), Color::BrightYellow);
+                self.write(&format!("\thint: {}", hint), Some(Color::BrightYellow));
             }
-            self.write("\n", Color::Reset);
+            self.write("\n", Some(Color::Reset));
         });
     }
 
@@ -240,7 +247,7 @@ impl Printer {
         reason: Option<&str>,
     ) {
         Printer::with_pos(src, print_pos, |pos, column, row, next_crlf, last_lf| {
-            self.write(header, Color::BrightRed);
+            self.write(header, Some(Color::BrightRed));
 
             let beg = if let Some(last_lf) = last_lf {
                 if next_crlf > last_lf {
@@ -261,33 +268,33 @@ impl Printer {
 
             let column_len = format!("{}", column).len();
 
-            self.write(&format!(": {}\n", description), Color::BrightWhite);
+            self.write(&format!(": {}\n", description), Some(Color::BrightWhite));
 
-            self.write("   -->", Color::BrightBlue);
+            self.write("   -->", Some(Color::BrightBlue));
 
             self.write(
                 &format!(" {}:{}:{}\n", path.to_string_lossy(), column, row),
-                Color::White,
+                Some(Color::White),
             );
 
             self.write(
                 &format!("{}|\n", " ".repeat(column_len + 1)),
-                Color::BrightBlue,
+                Some(Color::BrightBlue),
             );
 
-            self.write(&format!("{} |", column), Color::BrightBlue);
+            self.write(&format!("{} |", column), Some(Color::BrightBlue));
 
             self.write(
                 &format!(
                     " {}\n",
                     String::from_utf8_lossy(&src.as_bytes()[beg..next_crlf])
                 ),
-                Color::White,
+                Some(Color::White),
             );
 
             self.write(
                 &format!("{}|", " ".repeat(column_len + 1)),
-                Color::BrightBlue,
+                Some(Color::BrightBlue),
             );
 
             self.write(
@@ -296,17 +303,17 @@ impl Printer {
                     " ".repeat(pos - beg),
                     "^".repeat(cmp::min(print_pos + print_len, next_crlf) - print_pos)
                 ),
-                Color::BrightYellow,
+                Some(Color::BrightYellow),
             );
 
             if let Some(hint) = hint {
-                self.write(&format!(" hint  : {}\n", hint), Color::BrightYellow);
+                self.write(&format!(" hint  : {}\n", hint), Some(Color::BrightYellow));
             }
 
             if let Some(reason) = reason {
                 self.write(
                     &format!("{}|", " ".repeat(column_len + 1)),
-                    Color::BrightBlue,
+                    Some(Color::BrightBlue),
                 );
 
                 self.write(
@@ -315,13 +322,13 @@ impl Printer {
                         " ".repeat(pos - beg),
                         " ".repeat(cmp::min(print_pos + print_len, next_crlf) - print_pos)
                     ),
-                    Color::Yellow,
+                    Some(Color::Yellow),
                 );
 
-                self.write(&format!(" reason: {}\n", reason), Color::Yellow);
+                self.write(&format!(" reason: {}\n", reason), Some(Color::Yellow));
             }
 
-            self.write("\n", Color::Reset);
+            self.write("\n", Some(Color::Reset));
         });
     }
 
@@ -418,50 +425,50 @@ impl Printer {
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn print_error(&mut self, msg: &str) -> Result<(), Error> {
-        self.write("Error", Color::BrightRed);
-        self.write(&format!(": {}", msg), Color::BrightWhite);
-        self.write("\n", Color::Reset);
+        self.write("Error", Some(Color::BrightRed));
+        self.write(&format!(": {}", msg), Some(Color::BrightWhite));
+        self.write("\n", Some(Color::Reset));
         Ok(())
     }
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn print_warning(&mut self, msg: &str) -> Result<(), Error> {
-        self.write("Warning", Color::BrightYellow);
-        self.write(&format!(": {}", msg), Color::BrightWhite);
-        self.write("\n", Color::Reset);
+        self.write("Warning", Some(Color::BrightYellow));
+        self.write(&format!(": {}", msg), Some(Color::BrightWhite));
+        self.write("\n", Some(Color::Reset));
         Ok(())
     }
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn print_info(&mut self, msg: &str) -> Result<(), Error> {
-        self.write("Info", Color::BrightGreen);
-        self.write(&format!(": {}", msg), Color::BrightWhite);
-        self.write("\n", Color::Reset);
+        self.write("Info", Some(Color::BrightGreen));
+        self.write(&format!(": {}", msg), Some(Color::BrightWhite));
+        self.write("\n", Some(Color::Reset));
         Ok(())
     }
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn print_error_type(&mut self, error: Error) -> Result<(), Error> {
         let mut cause = error.chain();
-        self.write("Error", Color::BrightRed);
-        self.write(&format!(": {}", cause.next().unwrap()), Color::BrightWhite);
-        self.write("\n", Color::Reset);
+        self.write("Error", Some(Color::BrightRed));
+        self.write(&format!(": {}", cause.next().unwrap()), Some(Color::BrightWhite));
+        self.write("\n", Some(Color::Reset));
         for x in cause {
-            self.write(&format!("  caused by: {}\n", x), Color::Reset);
+            self.write(&format!("  caused by: {}\n", x), Some(Color::Reset));
         }
         Ok(())
     }
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn print(&mut self, msg: &str) -> Result<(), Error> {
-        self.write(msg, Color::Reset);
+        self.write(msg, None);
         Ok(())
     }
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn println(&mut self, msg: &str) -> Result<(), Error> {
-        self.write(msg, Color::Reset);
-        self.write("\n", Color::Reset);
+        self.write(msg, None);
+        self.write("\n", None);
         Ok(())
     }
 

--- a/testcases/expected/dump_filelist_6
+++ b/testcases/expected/dump_filelist_6
@@ -1,0 +1,6 @@
+child1_file1.sv
+child1_file2.sv
+child1_file1.sv
+parent1_file1.sv
+child2_file1.sv
+grandparent1_file1.sv

--- a/testcases/expected/dump_filelist_7
+++ b/testcases/expected/dump_filelist_7
@@ -1,0 +1,2 @@
+relative/path/to/directory
+/absolute/path/to/directory

--- a/testcases/expected/dump_filelist_8
+++ b/testcases/expected/dump_filelist_8
@@ -1,0 +1,9 @@
+$(VAR1)=var1
+$VAR3=var3
+${VAR2}=var2
+A=a
+B=b
+C=c
+VAR4
+a=123
+b=456


### PR DESCRIPTION
- Update sv-parser to v0.13.0, avoiding yanked v0.12.3
- Update clap from v3.1.18 to v3.2.* (currently v3.2.23) which is the minimum version to get ValueEnum.
  The authors of clap appear to have stopped releasing multiple versions per day for `v3.x`!
- Change `--dump-filelist` from bool to ValueEnum.
  - Previous behavior of not using the flag is equivalent to `--dump-filelist=no`, or just not using
    the flag (backwards compatible).
  - Previous behavior of using the flag is equivalent to `--dump-filelist=yaml`.
    That's a breaking change to the flag.
    The output is functionally equivalent (except for the removed control codes).
  - Possible values `files`, `incdirs`, `defines` give new modes where output is intended to be
    processed by shell scripts (see #224).
    One line per file/incdir/define, without control codes.
- Changed `printer.write()` so that it doesn't require a color, and `printer.print`,`printer.println` to
  avoid control codes for reset/clearing the terminal.
- Added unittests for new modes of `--dump-filelist`, but they can't check for control codes.