### PR TITLE
Bugfix: Addresses #210, #225, #235.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -466,11 +466,19 @@ Place `` `default_nettype none`` at the top of source code.
 
 Compiler directive `` `default_nettype none`` detects unintentional implicit wires.
 
-### Pass Example (1 of 1)
+### Pass Example (1 of 2)
 ```systemverilog
 `default_nettype none
 module M;
 endmodule
+```
+
+### Pass Example (2 of 2)
+```systemverilog
+/* svlint off default_nettype_none */
+module M;
+endmodule
+/* svlint on default_nettype_none */
 ```
 
 ### Fail Example (1 of 1)
@@ -7143,6 +7151,7 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.
 
 
@@ -7201,7 +7210,6 @@ This rule checks the whitespace immediately following these keywords:
 `break`
 , `continue`
 , `default`
-, `new`
 , `null`
 , `super`
 , and `this`.
@@ -7210,7 +7218,6 @@ the following symbol, e.g.
 `break;`,
 , `continue;`
 , `default:`
-, `new[5]`
 , `(myexample == null)`
 , or `super.foo`.
 
@@ -7223,6 +7230,7 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.
 
 
@@ -7291,6 +7299,7 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.
 
 
@@ -7525,6 +7534,7 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.
 
 
@@ -7623,6 +7633,7 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.
 
 
@@ -7707,6 +7718,7 @@ See also:
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.
 
 
@@ -7797,6 +7809,7 @@ See also:
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.
 
 
@@ -7896,6 +7909,103 @@ See also:
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
+- **style_keyword_newline** - Suggested companion rule.
+
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+## Rule: `style_keyword_new`
+
+### Hint
+
+Follow keyword with a newline or exactly 0 space.
+
+### Reason
+
+Consistent use of whitespace enhances readability by reducing visual noise.
+
+### Pass Example (1 of 1)
+```systemverilog
+class Packet; // Example from IEEE1800-2017, page 174.
+  integer command;
+
+  function new(); // Constructor without arguments.
+    command = IDLE;
+  endfunction
+endclass
+
+class C1 extends Packet;
+  function new // Constructor with arguments.
+    ( int cmd = IDLE
+    , int addr = 123
+    , int data = 0
+    );
+    command = cmd;
+  endfunction
+endclass
+
+class C2 extends C1;
+  function new;
+    super.new(5); // Super constructor.
+  endfunction
+endclass
+
+module M;
+  Packet p1 = new; // Construction without arguments
+
+  C1 p2 = new(1, 2, 3); // Construction with short arguments.
+
+  C2 p3 = new // Construction with long arguments.
+    ( STARTUP
+    , A_RATHER_LONG_CONSTANT_IDENTIFIER
+    , 456
+    );
+endmodule
+```
+
+### Fail Example (1 of 3)
+```systemverilog
+module M;
+  Packet p1 = new  ; // Spaces before semicolon.
+endmodule
+```
+
+### Fail Example (2 of 3)
+```systemverilog
+module M;
+  C1 p2 = new (1, 2, 3); // Spaces before parenthesis.
+endmodule
+```
+
+### Fail Example (3 of 3)
+```systemverilog
+module M;
+  C2 p3 = new// No space before comment.
+    ( STARTUP
+    , A_RATHER_LONG_CONSTANT_IDENTIFIER
+    , 456
+    );
+endmodule
+```
+
+### Explanation
+
+This rule checks the whitespace immediately following the`new` keyword.
+The class constructor keyword should always be followed by a newline,
+exactly 0 spaces then a symbol, or exactly 1 space then a comment.
+
+See also:
+- **style_keyword_indent** - Suggested companion rule.
+- **style_keyword_0or1space** - Suggested companion rule.
+- **style_keyword_0space** - Suggested companion rule.
+- **style_keyword_1or2space** - Suggested companion rule.
+- **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_construct** - Suggested companion rule.
+- **style_keyword_datatype** - Potential companion rule.
+- **style_keyword_end** - Suggested companion rule.
+- **style_keyword_maybelabel** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.
 
 
@@ -7969,6 +8079,7 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 
 
 
@@ -9003,6 +9114,7 @@ rules.style_keyword_construct = true
 rules.style_keyword_datatype = false # Overly restrictive.
 rules.style_keyword_end = true
 rules.style_keyword_maybelabel = true
+rules.style_keyword_new = true
 rules.style_keyword_newline = true
 ```
 

--- a/md/explanation-style_keyword_0or1space.md
+++ b/md/explanation-style_keyword_0or1space.md
@@ -14,4 +14,5 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.

--- a/md/explanation-style_keyword_0space.md
+++ b/md/explanation-style_keyword_0space.md
@@ -2,7 +2,6 @@ This rule checks the whitespace immediately following these keywords:
 `break`
 , `continue`
 , `default`
-, `new`
 , `null`
 , `super`
 , and `this`.
@@ -11,7 +10,6 @@ the following symbol, e.g.
 `break;`,
 , `continue;`
 , `default:`
-, `new[5]`
 , `(myexample == null)`
 , or `super.foo`.
 
@@ -24,4 +22,5 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.

--- a/md/explanation-style_keyword_1or2space.md
+++ b/md/explanation-style_keyword_1or2space.md
@@ -25,4 +25,5 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.

--- a/md/explanation-style_keyword_1space.md
+++ b/md/explanation-style_keyword_1space.md
@@ -188,4 +188,5 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.

--- a/md/explanation-style_keyword_construct.md
+++ b/md/explanation-style_keyword_construct.md
@@ -43,4 +43,5 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.

--- a/md/explanation-style_keyword_datatype.md
+++ b/md/explanation-style_keyword_datatype.md
@@ -40,4 +40,5 @@ See also:
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.

--- a/md/explanation-style_keyword_end.md
+++ b/md/explanation-style_keyword_end.md
@@ -33,4 +33,5 @@ See also:
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.

--- a/md/explanation-style_keyword_maybelabel.md
+++ b/md/explanation-style_keyword_maybelabel.md
@@ -48,4 +48,5 @@ See also:
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.

--- a/md/explanation-style_keyword_new.md
+++ b/md/explanation-style_keyword_new.md
@@ -1,22 +1,6 @@
-This rule checks the whitespace immediately following these keywords:
-, `endcase`
-, `endgenerate`
-, `endspecify`
-, `endtable`
-, `specify`
-, and `table`.
-These keywords are used to delimit code blocks and should always be followed by
-a newline or exactly 1 space then a comment, e.g:
-```systemverilog
-case (FOO)
-  ...
-endcase // Followed by a comment.
-
-// Followed by a newline.
-case (FOO)
-  ...
-endcase
-```
+This rule checks the whitespace immediately following the`new` keyword.
+The class constructor keyword should always be followed by a newline,
+exactly 0 spaces then a symbol, or exactly 1 space then a comment.
 
 See also:
 - **style_keyword_indent** - Suggested companion rule.
@@ -28,4 +12,4 @@ See also:
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
-- **style_keyword_new** - Suggested companion rule.
+- **style_keyword_newline** - Suggested companion rule.

--- a/md/ruleset-style.md
+++ b/md/ruleset-style.md
@@ -266,6 +266,7 @@ rules.style_keyword_construct = true
 rules.style_keyword_datatype = false # Overly restrictive.
 rules.style_keyword_end = true
 rules.style_keyword_maybelabel = true
+rules.style_keyword_new = true
 rules.style_keyword_newline = true
 ```
 

--- a/rulesets/style.toml
+++ b/rulesets/style.toml
@@ -17,5 +17,6 @@ rules.style_keyword_construct = true
 rules.style_keyword_datatype = false # Overly restrictive.
 rules.style_keyword_end = true
 rules.style_keyword_maybelabel = true
+rules.style_keyword_new = true
 rules.style_keyword_newline = true
 rules.style_commaleading = true

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -208,3 +208,24 @@ pub fn check_regex(
         RuleResult::Fail
     }
 }
+
+// Utility function used by rules `prefix_*`.
+pub fn check_prefix(
+    id: Option<RefNode>,
+    syntax_tree: &SyntaxTree,
+    prefix: &String,
+) -> RuleResult {
+    let loc: &Locate = match id {
+        Some(x) => unwrap_locate!(x),
+        _ => None,
+    }
+    .unwrap();
+
+    let is_prefixed: bool = syntax_tree.get_str(loc).unwrap().starts_with(prefix);
+
+    if is_prefixed {
+        RuleResult::Pass
+    } else {
+        RuleResult::Fail
+    }
+}

--- a/src/rules/explicit_case_default.rs
+++ b/src/rules/explicit_case_default.rs
@@ -45,23 +45,6 @@ impl Rule for ExplicitCaseDefault {
             }
             _ => RuleResult::Pass,
         }
-        /*
-        match node {
-            RefNode::AlwaysConstruct(x) => {
-                if let Some(x) = unwrap_node!(*x, CaseStatementNormal) {
-                    let loc = unwrap_locate!(x.clone()).unwrap();
-                    let a = unwrap_node!(x, CaseItemDefault);
-                    if a.is_some() {
-                        RuleResult::Pass
-                    } else {
-                        RuleResult::FailLocate(*loc)
-                    }
-                } else {
-                    RuleResult::Pass
-                }
-            }
-            _ => RuleResult::Pass,
-        }*/
     }
 
     fn name(&self) -> String {

--- a/src/rules/prefix_inout.rs
+++ b/src/rules/prefix_inout.rs
@@ -1,8 +1,6 @@
 use crate::config::ConfigOption;
-use crate::linter::{Rule, RuleResult};
-use sv_parser::{
-    unwrap_locate, unwrap_node, Locate, NodeEvent, PortDirection, RefNode, SyntaxTree,
-};
+use crate::linter::{check_prefix, Rule, RuleResult};
+use sv_parser::{unwrap_node, NodeEvent, PortDirection, RefNode, SyntaxTree};
 
 #[derive(Default)]
 pub struct PrefixInout;
@@ -28,24 +26,10 @@ impl Rule for PrefixInout {
                     _ => false,
                 };
 
-                let id: Option<&Locate> = match unwrap_node!(*x, PortIdentifier) {
-                    Some(RefNode::PortIdentifier(id_)) => {
-                        unwrap_locate!(id_)
-                    }
-                    _ => None,
-                };
-
-                let is_prefixed: bool = match &id {
-                    Some(x) => syntax_tree
-                        .get_str(*x)
-                        .unwrap()
-                        .starts_with(&option.prefix_inout),
-                    _ => false,
-                };
-
-                match (is_inout, is_prefixed) {
-                    (true, false) => RuleResult::Fail,
-                    _ => RuleResult::Pass,
+                if is_inout {
+                    check_prefix(unwrap_node!(*x, PortIdentifier), &syntax_tree, &option.prefix_inout)
+                } else {
+                    RuleResult::Pass
                 }
             }
             _ => RuleResult::Pass,

--- a/src/rules/prefix_input.rs
+++ b/src/rules/prefix_input.rs
@@ -1,8 +1,6 @@
 use crate::config::ConfigOption;
-use crate::linter::{Rule, RuleResult};
-use sv_parser::{
-    unwrap_locate, unwrap_node, Locate, NodeEvent, PortDirection, RefNode, SyntaxTree,
-};
+use crate::linter::{check_prefix, Rule, RuleResult};
+use sv_parser::{unwrap_node, NodeEvent, PortDirection, RefNode, SyntaxTree};
 
 #[derive(Default)]
 pub struct PrefixInput;
@@ -28,24 +26,10 @@ impl Rule for PrefixInput {
                     _ => false,
                 };
 
-                let id: Option<&Locate> = match unwrap_node!(*x, PortIdentifier) {
-                    Some(RefNode::PortIdentifier(id_)) => {
-                        unwrap_locate!(id_)
-                    }
-                    _ => None,
-                };
-
-                let is_prefixed: bool = match &id {
-                    Some(x) => syntax_tree
-                        .get_str(*x)
-                        .unwrap()
-                        .starts_with(&option.prefix_input),
-                    _ => false,
-                };
-
-                match (is_input, is_prefixed) {
-                    (true, false) => RuleResult::Fail,
-                    _ => RuleResult::Pass,
+                if is_input {
+                    check_prefix(unwrap_node!(*x, PortIdentifier), &syntax_tree, &option.prefix_input)
+                } else {
+                    RuleResult::Pass
                 }
             }
             _ => RuleResult::Pass,

--- a/src/rules/prefix_instance.rs
+++ b/src/rules/prefix_instance.rs
@@ -1,6 +1,6 @@
 use crate::config::ConfigOption;
-use crate::linter::{Rule, RuleResult};
-use sv_parser::{unwrap_locate, unwrap_node, Locate, NodeEvent, RefNode, SyntaxTree};
+use crate::linter::{check_prefix, Rule, RuleResult};
+use sv_parser::{unwrap_node, NodeEvent, RefNode, SyntaxTree};
 
 #[derive(Default)]
 pub struct PrefixInstance;
@@ -20,26 +20,7 @@ impl Rule for PrefixInstance {
         };
         match node {
             RefNode::NameOfInstance(x) => {
-                let id: Option<&Locate> = match unwrap_node!(*x, InstanceIdentifier) {
-                    Some(RefNode::InstanceIdentifier(id_)) => {
-                        unwrap_locate!(id_)
-                    }
-                    _ => None,
-                };
-
-                let is_prefixed: bool = match &id {
-                    Some(x) => syntax_tree
-                        .get_str(*x)
-                        .unwrap()
-                        .starts_with(&option.prefix_instance),
-                    _ => false,
-                };
-
-                if is_prefixed {
-                    RuleResult::Pass
-                } else {
-                    RuleResult::Fail
-                }
+                check_prefix(unwrap_node!(*x, InstanceIdentifier), &syntax_tree, &option.prefix_instance)
             }
             _ => RuleResult::Pass,
         }

--- a/src/rules/prefix_interface.rs
+++ b/src/rules/prefix_interface.rs
@@ -1,6 +1,6 @@
 use crate::config::ConfigOption;
-use crate::linter::{Rule, RuleResult};
-use sv_parser::{unwrap_locate, unwrap_node, Locate, NodeEvent, RefNode, SyntaxTree};
+use crate::linter::{check_prefix, Rule, RuleResult};
+use sv_parser::{unwrap_node, NodeEvent, RefNode, SyntaxTree};
 
 #[derive(Default)]
 pub struct PrefixInterface;
@@ -19,27 +19,8 @@ impl Rule for PrefixInterface {
             }
         };
         match node {
-            RefNode::InterfaceIdentifier(x) => {
-                let id: Option<&Locate> = match unwrap_node!(*x, SimpleIdentifier) {
-                    Some(RefNode::SimpleIdentifier(id_)) => {
-                        unwrap_locate!(id_)
-                    }
-                    _ => None,
-                };
-
-                let is_prefixed: bool = match &id {
-                    Some(x) => syntax_tree
-                        .get_str(*x)
-                        .unwrap()
-                        .starts_with(&option.prefix_interface),
-                    _ => false,
-                };
-
-                if is_prefixed {
-                    RuleResult::Pass
-                } else {
-                    RuleResult::Fail
-                }
+            RefNode::InterfaceDeclaration(x) => {
+                check_prefix(unwrap_node!(*x, InterfaceIdentifier), &syntax_tree, &option.prefix_interface)
             }
             _ => RuleResult::Pass,
         }

--- a/src/rules/prefix_module.rs
+++ b/src/rules/prefix_module.rs
@@ -1,6 +1,6 @@
 use crate::config::ConfigOption;
-use crate::linter::{Rule, RuleResult};
-use sv_parser::{unwrap_locate, unwrap_node, Locate, NodeEvent, RefNode, SyntaxTree};
+use crate::linter::{check_prefix, Rule, RuleResult};
+use sv_parser::{unwrap_node, NodeEvent, RefNode, SyntaxTree};
 
 #[derive(Default)]
 pub struct PrefixModule;
@@ -20,12 +20,10 @@ impl Rule for PrefixModule {
         };
         match node {
             RefNode::ModuleAnsiHeader(x) => {
-                require_prefix(unwrap_node!(*x, ModuleIdentifier),
-                               &syntax_tree, &option.prefix_module)
+                check_prefix(unwrap_node!(*x, ModuleIdentifier), &syntax_tree, &option.prefix_module)
             }
             RefNode::ModuleNonansiHeader(x) => {
-                require_prefix(unwrap_node!(*x, ModuleIdentifier),
-                               &syntax_tree, &option.prefix_module)
+                check_prefix(unwrap_node!(*x, ModuleIdentifier), &syntax_tree, &option.prefix_module)
             }
             _ => RuleResult::Pass,
         }
@@ -44,35 +42,5 @@ impl Rule for PrefixModule {
 
     fn reason(&self) -> String {
         String::from("Naming convention simplifies audit.")
-    }
-}
-
-fn require_prefix(
-    id: Option<RefNode>,
-    syntax_tree: &SyntaxTree,
-    prefix: &str,
-) -> RuleResult {
-    let loc: Option<&Locate> = match id {
-        Some(x) => match unwrap_node!(x, SimpleIdentifier) {
-            Some(RefNode::SimpleIdentifier(id_)) => {
-                unwrap_locate!(id_)
-            }
-            _ => None,
-        }
-        _ => None,
-    };
-
-    let is_prefixed: bool = match loc {
-        Some(x) => syntax_tree
-            .get_str(x)
-            .unwrap()
-            .starts_with(prefix),
-        _ => false,
-    };
-
-    if is_prefixed {
-        RuleResult::Pass
-    } else {
-        RuleResult::Fail
     }
 }

--- a/src/rules/prefix_output.rs
+++ b/src/rules/prefix_output.rs
@@ -1,8 +1,6 @@
 use crate::config::ConfigOption;
-use crate::linter::{Rule, RuleResult};
-use sv_parser::{
-    unwrap_locate, unwrap_node, Locate, NodeEvent, PortDirection, RefNode, SyntaxTree,
-};
+use crate::linter::{check_prefix, Rule, RuleResult};
+use sv_parser::{unwrap_node, NodeEvent, PortDirection, RefNode, SyntaxTree};
 
 #[derive(Default)]
 pub struct PrefixOutput;
@@ -28,24 +26,10 @@ impl Rule for PrefixOutput {
                     _ => false,
                 };
 
-                let id: Option<&Locate> = match unwrap_node!(*x, PortIdentifier) {
-                    Some(RefNode::PortIdentifier(id_)) => {
-                        unwrap_locate!(id_)
-                    }
-                    _ => None,
-                };
-
-                let is_prefixed: bool = match &id {
-                    Some(x) => syntax_tree
-                        .get_str(*x)
-                        .unwrap()
-                        .starts_with(&option.prefix_output),
-                    _ => false,
-                };
-
-                match (is_output, is_prefixed) {
-                    (true, false) => RuleResult::Fail,
-                    _ => RuleResult::Pass,
+                if is_output {
+                    check_prefix(unwrap_node!(*x, PortIdentifier), &syntax_tree, &option.prefix_output)
+                } else {
+                    RuleResult::Pass
                 }
             }
             _ => RuleResult::Pass,

--- a/src/rules/prefix_package.rs
+++ b/src/rules/prefix_package.rs
@@ -1,6 +1,6 @@
 use crate::config::ConfigOption;
-use crate::linter::{Rule, RuleResult};
-use sv_parser::{unwrap_locate, unwrap_node, Locate, NodeEvent, RefNode, SyntaxTree};
+use crate::linter::{check_prefix, Rule, RuleResult};
+use sv_parser::{unwrap_node, NodeEvent, RefNode, SyntaxTree};
 
 #[derive(Default)]
 pub struct PrefixPackage;
@@ -19,27 +19,8 @@ impl Rule for PrefixPackage {
             }
         };
         match node {
-            RefNode::PackageIdentifier(x) => {
-                let id: Option<&Locate> = match unwrap_node!(*x, SimpleIdentifier) {
-                    Some(RefNode::SimpleIdentifier(id_)) => {
-                        unwrap_locate!(id_)
-                    }
-                    _ => None,
-                };
-
-                let is_prefixed: bool = match &id {
-                    Some(x) => syntax_tree
-                        .get_str(*x)
-                        .unwrap()
-                        .starts_with(&option.prefix_package),
-                    _ => false,
-                };
-
-                if is_prefixed {
-                    RuleResult::Pass
-                } else {
-                    RuleResult::Fail
-                }
+            RefNode::PackageDeclaration(x) => {
+                check_prefix(unwrap_node!(*x, PackageIdentifier), &syntax_tree, &option.prefix_package)
             }
             _ => RuleResult::Pass,
         }

--- a/src/rules/style_keyword_new.rs
+++ b/src/rules/style_keyword_new.rs
@@ -4,13 +4,13 @@ use regex::Regex;
 use sv_parser::{NodeEvent, RefNode, SyntaxTree};
 
 #[derive(Default)]
-pub struct StyleKeyword0Space {
+pub struct StyleKeywordNew {
     re_split: Option<Regex>,
     re_kw: Option<Regex>,
     re_succ: Option<Regex>,
 }
 
-impl Rule for StyleKeyword0Space {
+impl Rule for StyleKeywordNew {
     fn check(
         &mut self,
         syntax_tree: &SyntaxTree,
@@ -21,25 +21,22 @@ impl Rule for StyleKeyword0Space {
         re_split extracts keyword from anything following it.
         re_kw is used to selectively apply this rule to specific keywords.
         re_succ matches what is allowed after the keyword.
-            - nothing, immediately followed by a symbol
+            - newline
+            - exactly 0space, then nothing
+            - exactly 1space, then comment
         */
         if self.re_split.is_none() {
             self.re_split = Some(Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap());
         }
         if self.re_kw.is_none() {
             let keywords =
-                [ "break" // {{{
-                , "continue"
-                , "default"
-                , "null"
-                , "super"
-                , "this"
+                [ "new" // {{{
                 ].join("|"); // }}}
 
             self.re_kw = Some(Regex::new(format!("^({})$", keywords).as_str()).unwrap());
         }
         if self.re_succ.is_none() {
-            self.re_succ = Some(Regex::new(r"^$").unwrap());
+            self.re_succ = Some(Regex::new(r"^([\n\v\f\r]|$| /)").unwrap());
         }
 
         let node = match event {
@@ -73,11 +70,11 @@ impl Rule for StyleKeyword0Space {
     }
 
     fn name(&self) -> String {
-        String::from("style_keyword_0space")
+        String::from("style_keyword_new")
     }
 
     fn hint(&self, _option: &ConfigOption) -> String {
-        String::from("Remove all whitespace between keyword and following symbol.")
+        String::from("Follow keyword with a newline or exactly 0 space.")
     }
 
     fn reason(&self) -> String {

--- a/testcases/fail/style_keyword_new.sv
+++ b/testcases/fail/style_keyword_new.sv
@@ -1,0 +1,15 @@
+module M;
+  Packet p1 = new  ; // Spaces before semicolon.
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  C1 p2 = new (1, 2, 3); // Spaces before parenthesis.
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  C2 p3 = new// No space before comment.
+    ( STARTUP
+    , A_RATHER_LONG_CONSTANT_IDENTIFIER
+    , 456
+    );
+endmodule

--- a/testcases/pass/default_nettype_none.sv
+++ b/testcases/pass/default_nettype_none.sv
@@ -1,3 +1,8 @@
 `default_nettype none
 module M;
 endmodule
+////////////////////////////////////////////////////////////////////////////////
+/* svlint off default_nettype_none */
+module M;
+endmodule
+/* svlint on default_nettype_none */

--- a/testcases/pass/style_keyword_new.sv
+++ b/testcases/pass/style_keyword_new.sv
@@ -1,0 +1,35 @@
+class Packet; // Example from IEEE1800-2017, page 174.
+  integer command;
+
+  function new(); // Constructor without arguments.
+    command = IDLE;
+  endfunction
+endclass
+
+class C1 extends Packet;
+  function new // Constructor with arguments.
+    ( int cmd = IDLE
+    , int addr = 123
+    , int data = 0
+    );
+    command = cmd;
+  endfunction
+endclass
+
+class C2 extends C1;
+  function new;
+    super.new(5); // Super constructor.
+  endfunction
+endclass
+
+module M;
+  Packet p1 = new; // Construction without arguments
+
+  C1 p2 = new(1, 2, 3); // Construction with short arguments.
+
+  C2 p3 = new // Construction with long arguments.
+    ( STARTUP
+    , A_RATHER_LONG_CONSTANT_IDENTIFIER
+    , 456
+    );
+endmodule


### PR DESCRIPTION
- #210 Alternate implementation of `default_nettype_none` which allows control comments to work such that the rule can be enabled/disabled for files with multiple modules.
  - Allows straightforward extension to support `` `resetall ``, but I'm unsure if that should be a different rule. 
- #225 Apply `prefix_package` and `prefix_interface` only to declarations, not everywhere that a package/interface identifier can be used.
  - Includes a minor tidy of the `prefix_*` rules to use a utility function `linter::check_prefix()`.
- #235 Create a new rule `style_keyword_new` and remove the `new` keyword from `style_keyword_0space`.
  - Includes corresponding minor changes to explanations of related rules.
  - Includes the corresponding minor change to ruleset-style.