### PR TITLE
Bugfix: insert plugins in enabled hashmap during load

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -73,6 +73,7 @@ impl Linter {
                 unsafe { lib.get(b"get_plugin") };
             if let Ok(get_plugin) = get_plugin {
                 let plugin = unsafe { Box::from_raw(get_plugin()) };
+                self.ctl_enabled.insert(plugin.name(), true);
                 self.rules.push(plugin);
             }
         }


### PR DESCRIPTION
This fixes a bug where svlint would panic when checking if the plugin rule is enabled or not.