### PR TITLE
Feature: Update plugin API.

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -92,12 +92,15 @@ impl Linter {
             self.plugins.push(lib);
             let lib = self.plugins.last().unwrap();
 
-            let get_plugin: Result<Symbol<extern "C" fn() -> *mut dyn SyntaxRule>, _> =
+            let get_plugin: Result<Symbol<extern "C" fn() -> Vec<*mut dyn SyntaxRule>>, _> =
                 unsafe { lib.get(b"get_plugin") };
             if let Ok(get_plugin) = get_plugin {
-                let plugin = unsafe { Box::from_raw(get_plugin()) };
-                self.ctl_enabled.insert(plugin.name(), true);
-                self.syntaxrules.push(plugin);
+                let vec = get_plugin();
+                for plug in vec {
+                    let plugin = unsafe { Box::from_raw(plug) };
+                    self.ctl_enabled.insert(plugin.name(), true);
+                    self.syntaxrules.push(plugin);
+                }
             }
         }
     }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -33,12 +33,6 @@ pub enum SyntaxRuleResult {
     FailLocate(Locate),
 }
 
-#[derive(Clone, Copy)]
-pub enum Rule {
-    Text(*mut dyn TextRule),
-    Syntax(*mut dyn SyntaxRule),
-}
-
 pub trait SyntaxRule: Sync + Send {
     fn check(
         &mut self,
@@ -253,6 +247,27 @@ impl Linter {
             }
         }
         ret
+    }
+}
+
+// Rule enum is for use by plugins.
+#[derive(Clone, Copy)]
+pub enum Rule {
+    Text(*mut dyn TextRule),
+    Syntax(*mut dyn SyntaxRule),
+}
+
+// Macro for use within plugins.
+// Example usage within a plugin's `get_plugin` function:
+//      let mut ret: Vec<Rule> = Vec::new();
+//      ret.push(pluginrule!(Syntax, SamplePlugin));
+#[macro_export]
+macro_rules! pluginrule {
+    ( $e:ident,$t:ty ) => {
+        {
+            let boxed = Box::<$t>::default();
+            Rule::$e(Box::into_raw(boxed))
+        }
     }
 }
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -51,13 +51,13 @@ pub trait TextRule: Sync + Send {
     fn hint(&self, config: &ConfigOption) -> String;
     fn reason(&self) -> String;
 
-	fn into_rule(self) -> Rule
-	where
-		Self: Sized + 'static,
-	{
-		let temp = Box::new(self);
-		Rule::Text(Box::into_raw(temp))
-	}
+    fn into_rule(self) -> Rule
+    where
+        Self: Sized + 'static,
+    {
+        let temp = Box::new(self);
+        Rule::Text(Box::into_raw(temp))
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -79,13 +79,13 @@ pub trait SyntaxRule: Sync + Send {
     fn hint(&self, config: &ConfigOption) -> String;
     fn reason(&self) -> String;
 
-	fn into_rule(self) -> Rule
-	where
-		Self: Sized + 'static,
-	{
-		let temp = Box::new(self);
-		Rule::Syntax(Box::into_raw(temp))
-	}
+    fn into_rule(self) -> Rule
+    where
+        Self: Sized + 'static,
+    {
+        let temp = Box::new(self);
+        Rule::Syntax(Box::into_raw(temp))
+    }
 }
 
 pub struct Linter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,17 +271,16 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
             let text: String = read_to_string(&path)?;
 
             let mut beg: usize = 0;
-            for line in text.lines() {
-                for failed in linter.textrules_check(&line, &path, &beg) {
+            for line in text.split_inclusive('\n') {
+                let line_stripped = line.trim_end_matches(&['\n', '\r']);
+
+                for failed in linter.textrules_check(&line_stripped, &path, &beg) {
                     pass = false;
                     if !opt.silent {
                         printer.print_failed(&failed, opt.single, opt.github_actions)?;
                     }
                 }
-
-                // Newlines are not included in each line and `text` does not
-                // contain CRLF because `read_to_string` convents CRLF to LF.
-                beg += line.len() + 1; // Track the beginning byte index.
+                beg += line.len();
             }
 
             match parse_sv_str(text.as_str(), &path, &defines, &includes, opt.ignore_include, false) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,7 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
 
     let mut linter = Linter::new(config);
     for plugin in &opt.plugins {
-        linter.load(&plugin);
+        linter.load(&plugin)?;
     }
 
     let mut defines = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,14 +171,18 @@ pub fn run_opt(printer: &mut Printer, opt: &Opt) -> Result<bool, Error> {
             _ => true,
         };
 
-        if !opt.silent && !do_dump_filelist && !opt.preprocess_only {
-            let msg = format!(
-                "Config file '{}' is not found. Enable all rules",
-                opt.config.to_string_lossy()
-            );
-            printer.print_warning(&msg)?;
+        if !opt.plugins.is_empty() {
+            Config::new()
+        } else {
+            if !opt.silent && !do_dump_filelist && !opt.preprocess_only {
+                let msg = format!(
+                    "Config file '{}' is not found. Enable all rules",
+                    opt.config.to_string_lossy()
+                );
+                printer.print_warning(&msg)?;
+            }
+            Config::new().enable_all()
         }
-        Config::new().enable_all()
     };
 
     run_opt_config(printer, opt, config)


### PR DESCRIPTION
- Change `linter.load()` to expect `Vec<Rule>` instead of `SyntaxRule`.
  This allows plugins to contain multiple rules of either `SyntaxRule` or `TextRule`.
- Provide a macro `pluginrules` to simplify `get_plugin`.
- Superceeds #251, Thanks @skjdbg :)
- Two plugin-related usability changes:
  1. Throw an error when a plugin can't be loaded, rather than silently ignoring it.
  2. When no `.svlint.toml` is found but `--plugin` is given, don't enable all rules.
- As per #253, this is intended to be merged before v0.8.0 is released.
- Fixes #256.