### PR TITLE
Improvement: Cleanup the command-line interface.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde                   = "1.0"
 serde_derive            = "1.0"
 serde_regex             = "1.1"
 clap                    = {version = "3.2", features = ["derive"]}
+clap_complete           = "3.2"
 sv-parser               = "0.13.1"
 term                    = "0.7"
 toml                    = "0.7"

--- a/rulesets/svlint-DaveMcEwan-design
+++ b/rulesets/svlint-DaveMcEwan-design
@@ -3,7 +3,8 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--example|--update"
+NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
+NONRULESET="${NONRULESET}|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-DaveMcEwan-design
+++ b/rulesets/svlint-DaveMcEwan-design
@@ -3,8 +3,10 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
-NONRULESET="${NONRULESET}|--example|--update"
+NONRULESET="-h|--help|-V|--version"
+NONRULESET="${NONRULESET}|--dump-filelist|--shell-completion"
+NONRULESET="${NONRULESET}|-E|--preprocess-only"
+NONRULESET="${NONRULESET}|--config-example|--config-update|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-DaveMcEwan-designnaming
+++ b/rulesets/svlint-DaveMcEwan-designnaming
@@ -3,7 +3,8 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--example|--update"
+NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
+NONRULESET="${NONRULESET}|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-DaveMcEwan-designnaming
+++ b/rulesets/svlint-DaveMcEwan-designnaming
@@ -3,8 +3,10 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
-NONRULESET="${NONRULESET}|--example|--update"
+NONRULESET="-h|--help|-V|--version"
+NONRULESET="${NONRULESET}|--dump-filelist|--shell-completion"
+NONRULESET="${NONRULESET}|-E|--preprocess-only"
+NONRULESET="${NONRULESET}|--config-example|--config-update|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-designintent
+++ b/rulesets/svlint-designintent
@@ -3,7 +3,8 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--example|--update"
+NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
+NONRULESET="${NONRULESET}|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-designintent
+++ b/rulesets/svlint-designintent
@@ -3,8 +3,10 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
-NONRULESET="${NONRULESET}|--example|--update"
+NONRULESET="-h|--help|-V|--version"
+NONRULESET="${NONRULESET}|--dump-filelist|--shell-completion"
+NONRULESET="${NONRULESET}|-E|--preprocess-only"
+NONRULESET="${NONRULESET}|--config-example|--config-update|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-parseonly
+++ b/rulesets/svlint-parseonly
@@ -3,7 +3,8 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--example|--update"
+NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
+NONRULESET="${NONRULESET}|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-parseonly
+++ b/rulesets/svlint-parseonly
@@ -3,8 +3,10 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
-NONRULESET="${NONRULESET}|--example|--update"
+NONRULESET="-h|--help|-V|--version"
+NONRULESET="${NONRULESET}|--dump-filelist|--shell-completion"
+NONRULESET="${NONRULESET}|-E|--preprocess-only"
+NONRULESET="${NONRULESET}|--config-example|--config-update|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-simsynth
+++ b/rulesets/svlint-simsynth
@@ -3,7 +3,8 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--example|--update"
+NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
+NONRULESET="${NONRULESET}|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-simsynth
+++ b/rulesets/svlint-simsynth
@@ -3,8 +3,10 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
-NONRULESET="${NONRULESET}|--example|--update"
+NONRULESET="-h|--help|-V|--version"
+NONRULESET="${NONRULESET}|--dump-filelist|--shell-completion"
+NONRULESET="${NONRULESET}|-E|--preprocess-only"
+NONRULESET="${NONRULESET}|--config-example|--config-update|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-style
+++ b/rulesets/svlint-style
@@ -3,7 +3,8 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--example|--update"
+NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
+NONRULESET="${NONRULESET}|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-style
+++ b/rulesets/svlint-style
@@ -3,8 +3,10 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
-NONRULESET="${NONRULESET}|--example|--update"
+NONRULESET="-h|--help|-V|--version"
+NONRULESET="${NONRULESET}|--dump-filelist|--shell-completion"
+NONRULESET="${NONRULESET}|-E|--preprocess-only"
+NONRULESET="${NONRULESET}|--config-example|--config-update|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-verifintent
+++ b/rulesets/svlint-verifintent
@@ -3,7 +3,8 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--example|--update"
+NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
+NONRULESET="${NONRULESET}|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/rulesets/svlint-verifintent
+++ b/rulesets/svlint-verifintent
@@ -3,8 +3,10 @@ set -e
 
 # If flag/options are given that don't use the ruleset config, simply run
 # svlint with the given arguments.
-NONRULESET="-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update"
-NONRULESET="${NONRULESET}|--example|--update"
+NONRULESET="-h|--help|-V|--version"
+NONRULESET="${NONRULESET}|--dump-filelist|--shell-completion"
+NONRULESET="${NONRULESET}|-E|--preprocess-only"
+NONRULESET="${NONRULESET}|--config-example|--config-update|--example|--update"
 if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
 then
   svlint $*

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,18 +37,20 @@ pub struct Opt {
     #[clap(short = 'f', long = "filelist", conflicts_with = "files")]
     pub filelist: Vec<PathBuf>,
 
-    /// Define
+    /// Define macro for preprocessor, e.g. `-D FOO` or `-D FOO=123`
     #[clap(
-        short = 'd',
+        short = 'D',
+        short_alias = 'd',
         long = "define",
         multiple_occurrences = true,
         number_of_values = 1
     )]
     pub defines: Vec<String>,
 
-    /// Include directory path
+    /// Include directory for preprocessor, e.g. `-I path/to/headerfiles/`
     #[clap(
-        short = 'i',
+        short = 'I',
+        short_alias = 'i',
         long = "include",
         multiple_occurrences = true,
         number_of_values = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,9 +74,9 @@ pub struct Opt {
     #[clap(long = "ignore-include")]
     pub ignore_include: bool,
 
-    /// Print results by single line
-    #[clap(short = '1')]
-    pub single: bool,
+    /// Print one rule failure message per line
+    #[clap(short = '1', long = "oneline")]
+    pub oneline: bool,
 
     /// Suppress messages
     #[clap(short = 's', long = "silent")]
@@ -262,7 +262,7 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
                     defines = new_defines;
                 }
                 Err(x) => {
-                    print_parser_error(printer, x, opt.single)?;
+                    print_parser_error(printer, x, opt.oneline)?;
                     pass = false;
                 }
             }
@@ -279,7 +279,7 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
                 for failed in linter.textrules_check(&line_stripped, &path, &beg) {
                     pass = false;
                     if !opt.silent {
-                        printer.print_failed(&failed, opt.single, opt.github_actions)?;
+                        printer.print_failed(&failed, opt.oneline, opt.github_actions)?;
                     }
                 }
                 beg += line.len();
@@ -294,7 +294,7 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
                         for failed in linter.syntaxrules_check(&syntax_tree, &node) {
                             pass = false;
                             if !opt.silent {
-                                printer.print_failed(&failed, opt.single, opt.github_actions)?;
+                                printer.print_failed(&failed, opt.oneline, opt.github_actions)?;
                             }
                         }
                     }
@@ -306,7 +306,7 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
                     }
                 }
                 Err(x) => {
-                    print_parser_error(printer, x, opt.single)?;
+                    print_parser_error(printer, x, opt.oneline)?;
                     pass = false;
                 }
             }
@@ -328,14 +328,14 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
 fn print_parser_error(
     printer: &mut Printer,
     error: SvParserError,
-    single: bool,
+    oneline: bool,
 ) -> Result<(), Error> {
     match error {
         SvParserError::Parse(Some((path, pos))) => {
-            printer.print_parse_error(&path, pos, single)?;
+            printer.print_parse_error(&path, pos, oneline)?;
         }
         SvParserError::Preprocess(Some((path, pos))) => {
-            printer.print_preprocess_error(&path, pos, single)?;
+            printer.print_preprocess_error(&path, pos, oneline)?;
         }
         SvParserError::Include { source: x } => {
             if let SvParserError::File { path: x, .. } = *x {

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ pub struct Opt {
     #[clap(value_enum, long = "dump-completion")]
     pub dump_completion: Option<clap_complete::Shell>,
 
-    /// Print syntax trees (for debug or syntax analysis)
+    /// Print syntax trees, useful for debug or syntax analysis
     #[clap(long = "dump-syntaxtree")]
     pub dump_syntaxtree: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ pub enum DumpFilelistMode {
 #[clap(long_version(option_env!("LONG_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))))]
 pub struct Opt {
     /// Source file(s)
-    #[clap(required_unless_present_any = &["filelist", "config-example", "config-update", "dump-completion"])]
+    #[clap(required_unless_present_any = &["filelist", "config-example", "config-update", "shell-completion"])]
     pub files: Vec<PathBuf>,
 
     /// Filelist file(s)
@@ -104,8 +104,8 @@ pub struct Opt {
     pub dump_filelist: Option<DumpFilelistMode>,
 
     /// Print shell completion script
-    #[clap(value_enum, long = "dump-completion")]
-    pub dump_completion: Option<clap_complete::Shell>,
+    #[clap(value_enum, long = "shell-completion")]
+    pub shell_completion: Option<clap_complete::Shell>,
 
     /// Print syntax trees, useful for debug or syntax analysis
     #[clap(long = "dump-syntaxtree")]
@@ -150,9 +150,9 @@ pub fn run_opt(printer: &mut Printer, opt: &Opt) -> Result<bool, Error> {
         return Ok(true);
     }
 
-    if let Some(generator) = opt.dump_completion {
+    if let Some(generator) = opt.shell_completion {
         let mut cmd = Opt::command();
-        dump_completion(generator, &mut cmd);
+        shell_completion(generator, &mut cmd);
         return Ok(true);
     }
 
@@ -490,7 +490,7 @@ fn dump_filelist(
     Ok(())
 }
 
-fn dump_completion<G: clap_complete::Generator>(gen: G, cmd: &mut clap::Command) {
+fn shell_completion<G: clap_complete::Generator>(gen: G, cmd: &mut clap::Command) {
     clap_complete::generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
 }
 
@@ -742,26 +742,26 @@ mod tests {
 
     #[test]
     #[allow(unused_variables)]
-    fn cli_dump_completion() {
+    fn cli_shell_completion() {
         // {{{
         let mut args = vec!["svlint"];
-        args.push("--dump-completion=bash");
+        args.push("--shell-completion=bash");
         let opt = Opt::parse_from(args.iter());
 
         let mut args = vec!["svlint"];
-        args.push("--dump-completion=elvish");
+        args.push("--shell-completion=elvish");
         let opt = Opt::parse_from(args.iter());
 
         let mut args = vec!["svlint"];
-        args.push("--dump-completion=fish");
+        args.push("--shell-completion=fish");
         let opt = Opt::parse_from(args.iter());
 
         let mut args = vec!["svlint"];
-        args.push("--dump-completion=powershell");
+        args.push("--shell-completion=powershell");
         let opt = Opt::parse_from(args.iter());
 
         let mut args = vec!["svlint"];
-        args.push("--dump-completion=zsh");
+        args.push("--shell-completion=zsh");
         let opt = Opt::parse_from(args.iter());
     } // }}}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ pub struct Opt {
     #[clap(required_unless_present_any = &["filelist", "config-example", "config-update"])]
     pub files: Vec<PathBuf>,
 
-    /// File list
+    /// Filelist file(s)
     #[clap(short = 'f', long = "filelist", conflicts_with = "files")]
     pub filelist: Vec<PathBuf>,
 
@@ -57,11 +57,11 @@ pub struct Opt {
     )]
     pub includes: Vec<PathBuf>,
 
-    /// TOML configuration file
+    /// TOML configuration file, searched for hierarchically upwards
     #[clap(short = 'c', long = "config", default_value = ".svlint.toml")]
     pub config: PathBuf,
 
-    /// Plugin file
+    /// Plugin file, e.g. `-p path/to/libfoo.so` or `-p path\to\foo.dll`
     #[clap(
         short = 'p',
         long = "plugin",
@@ -70,7 +70,7 @@ pub struct Opt {
     )]
     pub plugins: Vec<PathBuf>,
 
-    /// Ignore any include
+    /// Ignore all preprocessor `include directives
     #[clap(long = "ignore-include")]
     pub ignore_include: bool,
 
@@ -78,7 +78,7 @@ pub struct Opt {
     #[clap(short = '1', long = "oneline")]
     pub oneline: bool,
 
-    /// Suppress messages
+    /// Suppress printing, useful for scripting
     #[clap(short = 's', long = "silent")]
     pub silent: bool,
 
@@ -86,7 +86,7 @@ pub struct Opt {
     #[clap(short = 'v', long = "verbose")]
     pub verbose: bool,
 
-    /// Print message for GitHub Actions
+    /// Format rule failure messages for GitHub Actions
     #[clap(long = "github-actions")]
     pub github_actions: bool,
 
@@ -102,11 +102,11 @@ pub struct Opt {
     #[clap(value_enum, default_value = "no", long = "dump-filelist")]
     pub dump_filelist: DumpFilelistMode,
 
-    /// Print syntax trees
+    /// Print syntax trees (for debug or syntax analysis)
     #[clap(long = "dump-syntaxtree")]
     pub dump_syntaxtree: bool,
 
-    /// Print preprocessor output instead of performing checks
+    /// Print preprocessor output then exit before parsing syntax
     #[clap(short = 'E')]
     pub preprocess_only: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ pub struct Opt {
     pub dump_syntaxtree: bool,
 
     /// Print preprocessor output then exit before parsing syntax
-    #[clap(short = 'E')]
+    #[clap(short = 'E', long = "preprocess-only")]
     pub preprocess_only: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ pub enum DumpFilelistMode {
 #[clap(name = "svlint")]
 #[clap(long_version(option_env!("LONG_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))))]
 pub struct Opt {
-    /// Source file
-    #[clap(required_unless_present_any = &["filelist", "example", "update-config"])]
+    /// Source file(s)
+    #[clap(required_unless_present_any = &["filelist", "config-example", "config-update"])]
     pub files: Vec<PathBuf>,
 
     /// File list
@@ -88,13 +88,13 @@ pub struct Opt {
     #[clap(long = "github-actions")]
     pub github_actions: bool,
 
-    /// Update configuration
-    #[clap(long = "update")]
-    pub update_config: bool,
+    /// Update TOML configuration file in-place
+    #[clap(long = "config-update", alias = "update")]
+    pub config_update: bool,
 
-    /// Print TOML configuration example
-    #[clap(long = "example")]
-    pub example: bool,
+    /// Print an example TOML configuration
+    #[clap(long = "config-example", alias = "example")]
+    pub config_example: bool,
 
     /// Print data from filelists
     #[clap(value_enum, default_value = "no", long = "dump-filelist")]
@@ -136,7 +136,7 @@ pub fn main() {
 
 #[cfg_attr(tarpaulin, skip)]
 pub fn run_opt(printer: &mut Printer, opt: &Opt) -> Result<bool, Error> {
-    if opt.example {
+    if opt.config_example {
         let config = Config::new();
         let config = format!("{}", toml::to_string(&config).unwrap());
         printer.println(&config)?;
@@ -153,7 +153,7 @@ pub fn run_opt(printer: &mut Printer, opt: &Opt) -> Result<bool, Error> {
         let mut ret: Config = toml::from_str(&s)
             .with_context(|| format!("failed to parse toml '{}'", config.to_string_lossy()))?;
 
-        if opt.update_config {
+        if opt.config_update {
             ret.migrate();
             let mut f = OpenOptions::new()
                 .write(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,12 +30,12 @@ pub enum DumpFilelistMode {
 #[clap(long_version(option_env!("LONG_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))))]
 pub struct Opt {
     /// Source file(s)
-    #[clap(required_unless_present_any = &["filelist", "config-example", "config-update", "shell-completion"])]
+    #[clap(required_unless_present_any = &["filelists", "config-example", "config-update", "shell-completion"])]
     pub files: Vec<PathBuf>,
 
     /// Filelist file(s)
     #[clap(short = 'f', long = "filelist", conflicts_with = "files")]
-    pub filelist: Vec<PathBuf>,
+    pub filelists: Vec<PathBuf>,
 
     /// Define macro for preprocessor, e.g. `-D FOO` or `-D FOO=123`
     #[clap(
@@ -227,11 +227,11 @@ pub fn run_opt_config(printer: &mut Printer, opt: &Opt, config: Config) -> Resul
         defines.insert(ident, Some(define));
     }
 
-    let (files, incdirs) = if !opt.filelist.is_empty() {
+    let (files, incdirs) = if !opt.filelists.is_empty() {
         let mut files = opt.files.clone();
         let mut incdirs = opt.incdirs.clone();
 
-        for filelist in &opt.filelist {
+        for filelist in &opt.filelists {
             let (mut f, mut i, d) = parse_filelist(filelist)?;
             if let Some(DumpFilelistMode::Yaml) = opt.dump_filelist {
                 dump_filelist(printer, &DumpFilelistMode::Yaml, &filelist, &f, &i, &d)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -595,6 +595,425 @@ mod tests {
     include!(concat!(env!("OUT_DIR"), "/test.rs"));
 
     #[test]
+    #[allow(unused_variables)]
+    fn cli_oneline() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("-1");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--oneline");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_config() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("-c");
+        args.push("foo.toml");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--config");
+        args.push("foo.toml");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_config_example() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("--config-example");
+        let opt = Opt::parse_from(args.iter());
+
+        // Alias for backwards compatibility svlint v0.8.0 and earlier. ////////
+        let mut args = vec!["svlint"];
+        args.push("--example");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_config_update() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("--config-update");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--config");
+        args.push("foo.toml");
+        args.push("--config-update");
+        let opt = Opt::parse_from(args.iter());
+
+        // Alias for backwards compatibility svlint v0.8.0 and earlier. ////////
+        let mut args = vec!["svlint"];
+        args.push("--update");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_defines() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("-D");
+        args.push("FOO");
+        args.push("-D");
+        args.push("BAR");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-D");
+        args.push("FOO=123");
+        args.push("-D");
+        args.push("BAR=456");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-DFOO");
+        args.push("-DBAR");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-DFOO=123");
+        args.push("-DBAR=456");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        // Long option. ////////////////////////////////////////////////////////
+        let mut args = vec!["svlint"];
+        args.push("--define");
+        args.push("FOO");
+        args.push("--define");
+        args.push("BAR");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--define");
+        args.push("FOO=123");
+        args.push("--define");
+        args.push("BAR=456");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        // Alias for backwards compatibility svlint v0.8.0 and earlier. ////////
+        let mut args = vec!["svlint"];
+        args.push("-d");
+        args.push("FOO");
+        args.push("-d");
+        args.push("BAR");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-d");
+        args.push("FOO=123");
+        args.push("-d");
+        args.push("BAR=456");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-dFOO");
+        args.push("-dBAR");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-dFOO=123");
+        args.push("-dBAR=456");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_dump_completion() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("--dump-completion=bash");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--dump-completion=elvish");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--dump-completion=fish");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--dump-completion=powershell");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--dump-completion=zsh");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_dump_filelist() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist=yaml");
+        args.push("--filelist");
+        args.push("foo.f");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist=files");
+        args.push("--filelist");
+        args.push("foo.f");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--filelist");
+        args.push("foo.f");
+        args.push("--dump-filelist=incdirs");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--filelist");
+        args.push("foo.f");
+        args.push("--dump-filelist=defines");
+
+        // Without the -f/--filelist. //////////////////////////////////////////
+        // Useful for debugging other ways of passing long/complex commands.
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist=yaml");
+        args.push("-DFOO");
+        args.push("-Ipath/to/headers/");
+        args.push("foo.sv");
+        args.push("bar.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist=files");
+        args.push("-DFOO");
+        args.push("-Ipath/to/headers/");
+        args.push("foo.sv");
+        args.push("bar.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist=incdirs");
+        args.push("-DFOO");
+        args.push("-Ipath/to/headers/");
+        args.push("foo.sv");
+        args.push("bar.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--dump-filelist=defines");
+        args.push("-DFOO");
+        args.push("-Ipath/to/headers/");
+        args.push("foo.sv");
+        args.push("bar.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_dump_syntaxtree() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("--dump-syntaxtree");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_preprocess_only() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("-E");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--preprocess-only");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_filelist() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("-f");
+        args.push("Foo.f");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-fFoo.f");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--filelist");
+        args.push("foo.f");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_github_actions() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("--github-actions");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    // NOTE: Testing clap's -h/--help interfers with `cargo test`.
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_incdirs() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("-I");
+        args.push("path/to/foo");
+        args.push("-I");
+        args.push("/path/to/bar");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-Ipath/to/foo");
+        args.push("-I/path/to/bar");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--incdir");
+        args.push("path/to/foo");
+        args.push("--incdir");
+        args.push("/path/to/bar");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        // Aliases for backwards compatibility svlint v0.8.0 and earlier. //////
+        let mut args = vec!["svlint"];
+        args.push("-i");
+        args.push("path/to/foo");
+        args.push("-i");
+        args.push("/path/to/bar");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-ipath/to/foo");
+        args.push("-i/path/to/bar");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--include");
+        args.push("path/to/foo");
+        args.push("--include");
+        args.push("/path/to/bar");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_ignore_include() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("--ignore-include");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_plugins() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("-p");
+        args.push("path/to/libfoo.so"); // Linux
+        args.push("-p");
+        args.push("path/to/libbar.so");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-p");
+        args.push("path/to/libfoo.dylib"); // MacOS
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-p");
+        args.push("path\\to\\foo.dll"); // Windows
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("-pfoo.so");
+        args.push("-pbar.so");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--plugin");
+        args.push("foo.so");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_silent() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("-s");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--silent");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    #[test]
+    #[allow(unused_variables)]
+    fn cli_verbose() {
+        // {{{
+        let mut args = vec!["svlint"];
+        args.push("-v");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+
+        let mut args = vec!["svlint"];
+        args.push("--verbose");
+        args.push("foo.sv");
+        let opt = Opt::parse_from(args.iter());
+    } // }}}
+
+    // NOTE: Testing clap's -V/--version interfers with `cargo test`.
+
+    #[test]
     fn dump_filelist_1() {
         // {{{
         let config: Config = toml::from_str("").unwrap();

--- a/src/mdgen.rs
+++ b/src/mdgen.rs
@@ -280,7 +280,8 @@ fn write_ruleset_sh(ruleset: &Ruleset) -> () {
         let _ = writeln!(o, "");
         let _ = writeln!(o, "# If flag/options are given that don't use the ruleset config, simply run");
         let _ = writeln!(o, "# svlint with the given arguments.");
-        let _ = writeln!(o, "NONRULESET=\"-h|--help|-V|--version|--dump-filelist|-E|--example|--update\"");
+        let _ = writeln!(o, "NONRULESET=\"-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update\"");
+        let _ = writeln!(o, "NONRULESET=\"${{NONRULESET}}|--example|--update\"");
         let _ = writeln!(o, "if printf \"%b\\n\" \" $*\" | grep -Eq \" (${{NONRULESET}})\";");
         let _ = writeln!(o, "then");
         let _ = writeln!(o, "  svlint $*");

--- a/src/mdgen.rs
+++ b/src/mdgen.rs
@@ -280,8 +280,10 @@ fn write_ruleset_sh(ruleset: &Ruleset) -> () {
         let _ = writeln!(o, "");
         let _ = writeln!(o, "# If flag/options are given that don't use the ruleset config, simply run");
         let _ = writeln!(o, "# svlint with the given arguments.");
-        let _ = writeln!(o, "NONRULESET=\"-h|--help|-V|--version|--dump-filelist|-E|--config-example|--config-update\"");
-        let _ = writeln!(o, "NONRULESET=\"${{NONRULESET}}|--example|--update\"");
+        let _ = writeln!(o, "NONRULESET=\"-h|--help|-V|--version\"");
+        let _ = writeln!(o, "NONRULESET=\"${{NONRULESET}}|--dump-filelist|--shell-completion\"");
+        let _ = writeln!(o, "NONRULESET=\"${{NONRULESET}}|-E|--preprocess-only\"");
+        let _ = writeln!(o, "NONRULESET=\"${{NONRULESET}}|--config-example|--config-update|--example|--update\"");
         let _ = writeln!(o, "if printf \"%b\\n\" \" $*\" | grep -Eq \" (${{NONRULESET}})\";");
         let _ = writeln!(o, "then");
         let _ = writeln!(o, "  svlint $*");

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -206,7 +206,7 @@ impl Printer {
     }
 
     #[cfg_attr(tarpaulin, skip)]
-    fn print_single(
+    fn print_oneline(
         &mut self,
         src: &str,
         print_pos: usize,
@@ -332,7 +332,7 @@ impl Printer {
     pub fn print_failed(
         &mut self,
         failed: &LintFailed,
-        single: bool,
+        oneline: bool,
         github_actions: bool,
     ) -> Result<(), Error> {
         let mut f = File::open(&failed.path)
@@ -340,8 +340,8 @@ impl Printer {
         let mut s = String::new();
         let _ = f.read_to_string(&mut s);
 
-        if single {
-            self.print_single(&s, failed.beg, "Fail", &failed.path, Some(&failed.hint));
+        if oneline {
+            self.print_oneline(&s, failed.beg, "Fail", &failed.path, Some(&failed.hint));
         } else {
             self.print_pretty(
                 &s,
@@ -375,15 +375,15 @@ impl Printer {
         &mut self,
         path: &Path,
         error_pos: usize,
-        single: bool,
+        oneline: bool,
     ) -> Result<(), Error> {
         let mut f = File::open(path)
             .with_context(|| format!("failed to open: '{}'", path.to_string_lossy()))?;
         let mut s = String::new();
         let _ = f.read_to_string(&mut s);
 
-        if single {
-            self.print_single(&s, error_pos, "Error", path, Some("parse error"));
+        if oneline {
+            self.print_oneline(&s, error_pos, "Error", path, Some("parse error"));
         } else {
             self.print_pretty(&s, error_pos, 1, "Error", "parse error", path, None, None);
         }
@@ -395,15 +395,15 @@ impl Printer {
         &mut self,
         path: &Path,
         error_pos: usize,
-        single: bool,
+        oneline: bool,
     ) -> Result<(), Error> {
         let mut f = File::open(path)
             .with_context(|| format!("failed to open: '{}'", path.to_string_lossy()))?;
         let mut s = String::new();
         let _ = f.read_to_string(&mut s);
 
-        if single {
-            self.print_single(&s, error_pos, "Error", path, Some("preprocess error"));
+        if oneline {
+            self.print_oneline(&s, error_pos, "Error", path, Some("preprocess error"));
         } else {
             self.print_pretty(
                 &s,


### PR DESCRIPTION
- Rename options to make the whole interface consistent and intuitive for new users.
  - `--example` -> `--config-example`
  - `--update` -> `--config-update`
  - Backwards compatibility maintained with aliases.
- Rename options to be consistent with other tools (GCC, Clang, Verilator, etc.).
  - `-i/--include` -> `-I/incdir` (also consistent with filelist plusarg/keyword)
  - `-d` -> `-D`
  - Backwards compatibility maintained with aliases.
- Remove unnecessary choice `--dump-filelist=no`.
  Technically a breaking change, but I doubt it is ever used in practice.
- Add long format for every option.
  - `-E` + `--preprocess-only`
  - `-1` + `--oneline` (consistent with Git)
- Add new option `--shell-completion` to print shell completion scripts to STDOUT.
  - Fixes #245 which requested this feature.
  - Based on the [example](https://github.com/clap-rs/clap/blob/clap_complete-v3.2.5/clap_complete/examples/completion-derive.rs) provided with clap.
- Add tests for all options, to detect backwards compatibility regressions in the future.
- Rephrase help messages so they're all consistent with each other.
- Renamed internal variables to match option names, just for code clarity.