### PR TITLE
Feature: Provide wrapper scripts for svls, in addition to svlint.

### DIFF
--- a/rulesets/svls-DaveMcEwan-design
+++ b/rulesets/svls-DaveMcEwan-design
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+# If flag/options are given that don't use the ruleset config, simply run
+# svls with the given arguments.
+NONRULESET="-h|--help|-V|--version"
+if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
+then
+  svls $*
+  exit $?
+fi
+
+SVLINT_CONFIG="$(dirname $(command -v svls-DaveMcEwan-design))/DaveMcEwan-design.toml"
+
+env SVLINT_CONFIG="${SVLINT_CONFIG}" svls $*

--- a/rulesets/svls-DaveMcEwan-design.cmd
+++ b/rulesets/svls-DaveMcEwan-design.cmd
@@ -1,0 +1,7 @@
+
+@echo off
+for /f %%E in ('where.exe svls-DaveMcEwan-design') do (
+    set "SVLINT_CONFIG=%%~dpEDaveMcEwan-design.toml"
+)
+svls %*
+

--- a/rulesets/svls-DaveMcEwan-designnaming
+++ b/rulesets/svls-DaveMcEwan-designnaming
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+# If flag/options are given that don't use the ruleset config, simply run
+# svls with the given arguments.
+NONRULESET="-h|--help|-V|--version"
+if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
+then
+  svls $*
+  exit $?
+fi
+
+SVLINT_CONFIG="$(dirname $(command -v svls-DaveMcEwan-designnaming))/DaveMcEwan-designnaming.toml"
+
+env SVLINT_CONFIG="${SVLINT_CONFIG}" svls $*

--- a/rulesets/svls-DaveMcEwan-designnaming.cmd
+++ b/rulesets/svls-DaveMcEwan-designnaming.cmd
@@ -1,0 +1,7 @@
+
+@echo off
+for /f %%E in ('where.exe svls-DaveMcEwan-designnaming') do (
+    set "SVLINT_CONFIG=%%~dpEDaveMcEwan-designnaming.toml"
+)
+svls %*
+

--- a/rulesets/svls-designintent
+++ b/rulesets/svls-designintent
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+# If flag/options are given that don't use the ruleset config, simply run
+# svls with the given arguments.
+NONRULESET="-h|--help|-V|--version"
+if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
+then
+  svls $*
+  exit $?
+fi
+
+SVLINT_CONFIG="$(dirname $(command -v svls-designintent))/designintent.toml"
+
+env SVLINT_CONFIG="${SVLINT_CONFIG}" svls $*

--- a/rulesets/svls-designintent.cmd
+++ b/rulesets/svls-designintent.cmd
@@ -1,0 +1,7 @@
+
+@echo off
+for /f %%E in ('where.exe svls-designintent') do (
+    set "SVLINT_CONFIG=%%~dpEdesignintent.toml"
+)
+svls %*
+

--- a/rulesets/svls-parseonly
+++ b/rulesets/svls-parseonly
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+# If flag/options are given that don't use the ruleset config, simply run
+# svls with the given arguments.
+NONRULESET="-h|--help|-V|--version"
+if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
+then
+  svls $*
+  exit $?
+fi
+
+SVLINT_CONFIG="$(dirname $(command -v svls-parseonly))/parseonly.toml"
+
+env SVLINT_CONFIG="${SVLINT_CONFIG}" svls $*

--- a/rulesets/svls-parseonly.cmd
+++ b/rulesets/svls-parseonly.cmd
@@ -1,0 +1,7 @@
+
+@echo off
+for /f %%E in ('where.exe svls-parseonly') do (
+    set "SVLINT_CONFIG=%%~dpEparseonly.toml"
+)
+svls %*
+

--- a/rulesets/svls-simsynth
+++ b/rulesets/svls-simsynth
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+# If flag/options are given that don't use the ruleset config, simply run
+# svls with the given arguments.
+NONRULESET="-h|--help|-V|--version"
+if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
+then
+  svls $*
+  exit $?
+fi
+
+SVLINT_CONFIG="$(dirname $(command -v svls-simsynth))/simsynth.toml"
+
+env SVLINT_CONFIG="${SVLINT_CONFIG}" svls $*

--- a/rulesets/svls-simsynth.cmd
+++ b/rulesets/svls-simsynth.cmd
@@ -1,0 +1,7 @@
+
+@echo off
+for /f %%E in ('where.exe svls-simsynth') do (
+    set "SVLINT_CONFIG=%%~dpEsimsynth.toml"
+)
+svls %*
+

--- a/rulesets/svls-style
+++ b/rulesets/svls-style
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+# If flag/options are given that don't use the ruleset config, simply run
+# svls with the given arguments.
+NONRULESET="-h|--help|-V|--version"
+if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
+then
+  svls $*
+  exit $?
+fi
+
+SVLINT_CONFIG="$(dirname $(command -v svls-style))/style.toml"
+
+env SVLINT_CONFIG="${SVLINT_CONFIG}" svls $*

--- a/rulesets/svls-style.cmd
+++ b/rulesets/svls-style.cmd
@@ -1,0 +1,7 @@
+
+@echo off
+for /f %%E in ('where.exe svls-style') do (
+    set "SVLINT_CONFIG=%%~dpEstyle.toml"
+)
+svls %*
+

--- a/rulesets/svls-verifintent
+++ b/rulesets/svls-verifintent
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+# If flag/options are given that don't use the ruleset config, simply run
+# svls with the given arguments.
+NONRULESET="-h|--help|-V|--version"
+if printf "%b\n" " $*" | grep -Eq " (${NONRULESET})";
+then
+  svls $*
+  exit $?
+fi
+
+SVLINT_CONFIG="$(dirname $(command -v svls-verifintent))/verifintent.toml"
+
+env SVLINT_CONFIG="${SVLINT_CONFIG}" svls $*

--- a/rulesets/svls-verifintent.cmd
+++ b/rulesets/svls-verifintent.cmd
@@ -1,0 +1,7 @@
+
+@echo off
+for /f %%E in ('where.exe svls-verifintent') do (
+    set "SVLINT_CONFIG=%%~dpEverifintent.toml"
+)
+svls %*
+

--- a/src/mdgen.rs
+++ b/src/mdgen.rs
@@ -266,7 +266,7 @@ fn write_manual_md(
     }
 }
 
-fn write_ruleset_sh(ruleset: &Ruleset) -> () {
+fn write_ruleset_sh_svlint(ruleset: &Ruleset) -> () {
     let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let p = Path::new(&cargo_manifest_dir)
         .join("rulesets")
@@ -317,7 +317,41 @@ fn write_ruleset_sh(ruleset: &Ruleset) -> () {
     }
 }
 
-fn write_ruleset_cmd(ruleset: &Ruleset) -> () {
+fn write_ruleset_sh_svls(ruleset: &Ruleset) -> () {
+    let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let p = Path::new(&cargo_manifest_dir)
+        .join("rulesets")
+        .join(format!("svls-{}", ruleset.name));
+
+    {
+        let mut o = File::create(&p).unwrap();
+
+        let _ = writeln!(o, "#!/usr/bin/env sh");
+        let _ = writeln!(o, "set -e");
+        let _ = writeln!(o, "");
+        let _ = writeln!(o, "# If flag/options are given that don't use the ruleset config, simply run");
+        let _ = writeln!(o, "# svls with the given arguments.");
+        let _ = writeln!(o, "NONRULESET=\"-h|--help|-V|--version\"");
+        let _ = writeln!(o, "if printf \"%b\\n\" \" $*\" | grep -Eq \" (${{NONRULESET}})\";");
+        let _ = writeln!(o, "then");
+        let _ = writeln!(o, "  svls $*");
+        let _ = writeln!(o, "  exit $?");
+        let _ = writeln!(o, "fi");
+        let _ = writeln!(o, "");
+        let _ = writeln!(o, "SVLINT_CONFIG=\"$(dirname $(command -v svls-{0}))/{0}.toml\"", ruleset.name);
+        let _ = writeln!(o, "");
+        let _ = writeln!(o, "env SVLINT_CONFIG=\"${{SVLINT_CONFIG}}\" svls $*");
+    }
+
+    #[cfg(unix)]
+    {
+        use std::fs::{set_permissions, Permissions};
+        use std::os::unix::fs::PermissionsExt;
+        set_permissions(&p, Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+fn write_ruleset_cmd_svlint(ruleset: &Ruleset) -> () {
     let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let p = Path::new(&cargo_manifest_dir)
         .join("rulesets")
@@ -333,6 +367,22 @@ fn write_ruleset_cmd(ruleset: &Ruleset) -> () {
         let _ = write!(o, "{}\r\n", line);
     }
     let _ = write!(o, "svlint %*\r\n");
+    let _ = write!(o, "\r\n");
+}
+
+fn write_ruleset_cmd_svls(ruleset: &Ruleset) -> () {
+    let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let p = Path::new(&cargo_manifest_dir)
+        .join("rulesets")
+        .join(format!("svls-{}.cmd", ruleset.name));
+    let mut o = File::create(&p).unwrap();
+
+    let _ = write!(o, "\r\n");
+    let _ = write!(o, "@echo off\r\n");
+    let _ = write!(o, "for /f %%E in ('where.exe svls-{0}') do (\r\n", ruleset.name);
+    let _ = write!(o, "    set \"SVLINT_CONFIG=%%~dpE{0}.toml\"\r\n", ruleset.name);
+    let _ = write!(o, ")\r\n");
+    let _ = write!(o, "svls %*\r\n");
     let _ = write!(o, "\r\n");
 }
 
@@ -353,8 +403,10 @@ fn write_ruleset_toml(ruleset: &Ruleset) -> () {
 pub fn main() {
     let rulesets = get_rulesets();
     for ruleset in &rulesets {
-        write_ruleset_sh(ruleset);
-        write_ruleset_cmd(ruleset);
+        write_ruleset_sh_svlint(ruleset);
+        write_ruleset_sh_svls(ruleset);
+        write_ruleset_cmd_svlint(ruleset);
+        write_ruleset_cmd_svls(ruleset);
         write_ruleset_toml(ruleset);
     }
 


### PR DESCRIPTION
These are usable in Vim with vim-lsp like this:

```vim
if executable('svls-parseonly')
    au User lsp_setup call lsp#register_server({
        \ 'name': 'svls-parseonly',
        \ 'cmd': {server_info->['svls-parseonly']},
        \ 'whitelist': ['systemverilog'],
        \ })
endif
```

Users can configure their editor to use different commands via editor-specific interfaces like key-bindings, drop-down menus, etc.