### PR TITLE
Improvement: Bundle rulesets in release ZIP files.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
   build_pdf:

--- a/Makefile
+++ b/Makefile
@@ -86,23 +86,39 @@ RELEASE_MANUAL := pdf/svlint_MANUAL_${VERSION}.pdf
 
 release_lnx:
 	cargo build --release --target=x86_64-unknown-linux-musl
+	rm -rf tmp
 	mkdir -p tmp/bin/ tmp/doc/
 	cp ${RELEASE_MANUAL} tmp/doc/
-	cp target/x86_64-unknown-linux-musl/release/${BIN_NAME} tmp/bin/
 	cp rulesets/*.toml tmp/bin/
 	cp $$(find rulesets/ -type f -perm -u+x) tmp/bin/
+	cp target/x86_64-unknown-linux-musl/release/${BIN_NAME} tmp/bin/
 	cd tmp/ && \
 		zip ${BIN_NAME}-${VERSION}-x86_64-lnx.zip -r *
-	rm -rf tmp
+	mv tmp/${BIN_NAME}-${VERSION}-x86_64-lnx.zip ./
+	rm -rf tmp/
 
 release_win:
 	cargo build --release --target=x86_64-pc-windows-msvc
-	7z a ${BIN_NAME}-${VERSION}-x86_64-win.zip \
-		${RELEASE_MANUAL} \
-		target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe
+	rm -rf tmp
+	mkdir -p tmp/bin/ tmp/doc/
+	cp ${RELEASE_MANUAL} tmp/doc/
+	cp rulesets/*.toml tmp/bin/
+	cp rulesets/*.cmd tmp/bin/
+	cp target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe tmp/bin/
+	cd tmp && \
+		7z a ${BIN_NAME}-${VERSION}-x86_64-win.zip bin/ doc/
+	mv tmp/${BIN_NAME}-${VERSION}-x86_64-win.zip ./
+	rm -rf tmp/
 
 release_mac:
 	cargo build --release --target=x86_64-apple-darwin
-	zip -j ${BIN_NAME}-${VERSION}-x86_64-mac.zip \
-		${RELEASE_MANUAL} \
-		target/x86_64-apple-darwin/release/${BIN_NAME}
+	rm -rf tmp
+	mkdir -p tmp/bin/ tmp/doc/
+	cp ${RELEASE_MANUAL} tmp/doc/
+	cp rulesets/*.toml tmp/bin/
+	cp $$(find rulesets/ -type f -perm -u+x) tmp/bin/
+	cp target/x86_64-apple-darwin/release/${BIN_NAME} tmp/bin/
+	cd tmp/ && \
+		zip ${BIN_NAME}-${VERSION}-x86_64-mac.zip -r *
+	mv tmp/${BIN_NAME}-${VERSION}-x86_64-mac.zip ./
+	rm -rf tmp/

--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,7 @@ MANUAL-release: MANUAL.intermediateTex.md
 RELEASE_MANUAL := pdf/svlint_MANUAL_${VERSION}.pdf
 
 release_lnx:
-	#cargo build --release --target=x86_64-unknown-linux-musl
-	mkdir -p target/x86_64-unknown-linux-musl/release/
-	echo FOO > target/x86_64-unknown-linux-musl/release/${BIN_NAME}
-	# TODO: Undo above
+	cargo build --release --target=x86_64-unknown-linux-musl
 	rm -rf tmp
 	mkdir -p tmp/bin/ tmp/doc/
 	cp ${RELEASE_MANUAL} tmp/doc/
@@ -101,10 +98,7 @@ release_lnx:
 	rm -rf tmp/
 
 release_win:
-	#cargo build --release --target=x86_64-pc-windows-msvc
-	mkdir -p target/x86_64-pc-windows-msvc/release/
-	echo FOO > target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe
-	# TODO: Undo above
+	cargo build --release --target=x86_64-pc-windows-msvc
 	rm -rf tmp
 	mkdir -p tmp/bin/ tmp/doc/
 	cp ${RELEASE_MANUAL} tmp/doc/
@@ -117,10 +111,7 @@ release_win:
 	rm -rf tmp/
 
 release_mac:
-	#cargo build --release --target=x86_64-apple-darwin
-	mkdir -p target/x86_64-apple-darwin/release/
-	echo FOO > target/x86_64-apple-darwin/release/${BIN_NAME}
-	# TODO: Undo above
+	cargo build --release --target=x86_64-apple-darwin
 	rm -rf tmp
 	mkdir -p tmp/bin/ tmp/doc/
 	cp ${RELEASE_MANUAL} tmp/doc/

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ release_win:
 	cp rulesets/*.cmd tmp/bin/
 	cp target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe tmp/bin/
 	cd tmp && \
-		7z a ${BIN_NAME}-${VERSION}-x86_64-win.zip bin/ doc/
+		7z a ${BIN_NAME}-${VERSION}-x86_64-win.zip *
 	mv tmp/${BIN_NAME}-${VERSION}-x86_64-win.zip ./
 	rm -rf tmp/
 

--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,14 @@ RELEASE_MANUAL := pdf/svlint_MANUAL_${VERSION}.pdf
 
 release_lnx:
 	cargo build --release --target=x86_64-unknown-linux-musl
-	zip -j ${BIN_NAME}-${VERSION}-x86_64-lnx.zip \
-		${RELEASE_MANUAL} \
-		target/x86_64-unknown-linux-musl/release/${BIN_NAME}
+	mkdir -p tmp/bin/ tmp/doc/
+	cp ${RELEASE_MANUAL} tmp/doc/
+	cp target/x86_64-unknown-linux-musl/release/${BIN_NAME} tmp/bin/
+	cp rulesets/*.toml tmp/bin/
+	cp $$(find rulesets/ -type f -perm -u+x) tmp/bin/
+	cd tmp/ && \
+		zip ${BIN_NAME}-${VERSION}-x86_64-lnx.zip -r *
+	rm -rf tmp
 
 release_win:
 	cargo build --release --target=x86_64-pc-windows-msvc

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,10 @@ MANUAL-release: MANUAL.intermediateTex.md
 RELEASE_MANUAL := pdf/svlint_MANUAL_${VERSION}.pdf
 
 release_lnx:
-	cargo build --release --target=x86_64-unknown-linux-musl
+	#cargo build --release --target=x86_64-unknown-linux-musl
+	mkdir -p target/x86_64-unknown-linux-musl/release/
+	echo FOO > target/x86_64-unknown-linux-musl/release/${BIN_NAME}
+	# TODO: Undo above
 	rm -rf tmp
 	mkdir -p tmp/bin/ tmp/doc/
 	cp ${RELEASE_MANUAL} tmp/doc/
@@ -98,7 +101,10 @@ release_lnx:
 	rm -rf tmp/
 
 release_win:
-	cargo build --release --target=x86_64-pc-windows-msvc
+	#cargo build --release --target=x86_64-pc-windows-msvc
+	mkdir -p target/x86_64-pc-windows-msvc/release/
+	echo FOO > target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe
+	# TODO: Undo above
 	rm -rf tmp
 	mkdir -p tmp/bin/ tmp/doc/
 	cp ${RELEASE_MANUAL} tmp/doc/
@@ -111,7 +117,10 @@ release_win:
 	rm -rf tmp/
 
 release_mac:
-	cargo build --release --target=x86_64-apple-darwin
+	#cargo build --release --target=x86_64-apple-darwin
+	mkdir -p target/x86_64-apple-darwin/release/
+	echo FOO > target/x86_64-apple-darwin/release/${BIN_NAME}
+	# TODO: Undo above
 	rm -rf tmp
 	mkdir -p tmp/bin/ tmp/doc/
 	cp ${RELEASE_MANUAL} tmp/doc/

--- a/README.md
+++ b/README.md
@@ -17,12 +17,18 @@ Svlint is also integrated with most text editors via
 ## Installation
 
 svlint can be installed in several ways:
-- Download a [release](https://github.com/dalance/svlint/releases/latest), and
-  extract to a directory in your `$PATH`.
+- Download a [release](https://github.com/dalance/svlint/releases/latest),
+  extract, and add the `bin/` directory to your `$PATH`.
+  A PDF copy of the MANUAL is included in the `doc/` directory.
+- If you have a [Rust toolchain](https://www.rust-lang.org/tools/install), then
+  you can install the binary with [cargo](https://crates.io/crates/svlint), via
+  `cargo install svlint`.
+  This will copy the `svlint` binary (and the dev-only `mdgen` binary) to
+  ([usually](https://doc.rust-lang.org/cargo/commands/cargo-install.html#description))
+  `~/.cargo/bin`, but not the wrapper scripts (e.g. `svlint-parseonly`) or
+  pre-written configurations (e.g. `parseonly.toml`) from `rulesets/`.
 - [snapcraft](https://snapcraft.io/svlint), via
   `sudo snap install svlint`.
-- [cargo](https://crates.io/crates/svlint), via
-  `cargo install svlint`.
 
 
 ## Usage


### PR DESCRIPTION
Makes it easier to use rulesets for non-dev users that don't/won't clone the repo.

Before this PR, a release ZIP looked like:
```
svlint-v0.8.0-x86_64-lnx.zip
├── svlint                        <- The binary executable
└── svlint_MANUAL_v0.8.0.pdf      <- The documentation
```

With this PR, a release ZIP looks like:
```
svlint-v0.8.0-x86_64-lnx.zip
├── bin
│   ├── svlint                    <- The binary executable
│   ├── parseonly.toml            
│   ├── ... *.toml                <- TOML configurations
│   ├── svlint-parseonly
│   └── ... svlint-*              <- Wrapper scripts
└── doc
    └── svlint_MANUAL_v0.8.0.pdf  <- The documentation

```

Example ZIPs are here: <https://github.com/DaveMcEwan/svlint/releases/tag/v0.0.12-DONOTUSE>