### PR TITLE
Bugfix: Change textrules API to pass `line: Option<&str>`.

### DIFF
--- a/src/textrules/header_copyright.rs
+++ b/src/textrules/header_copyright.rs
@@ -5,15 +5,23 @@ use regex::Regex;
 #[derive(Default)]
 pub struct HeaderCopyright {
     re: Option<Regex>,
-    linenum: Option<usize>,
+    linenum: usize,
 }
 
 impl TextRule for HeaderCopyright {
     fn check(
         &mut self,
-        line: &str,
+        line: Option<&str>,
         option: &ConfigOption,
     ) -> TextRuleResult {
+        let line: &str = if line.is_none() {
+            self.linenum = 0;
+            return TextRuleResult::Pass;
+        } else {
+            line.unwrap()
+        };
+        self.linenum += 1;
+
         if self.re.is_none() {
             let year = &option.copyright_year;
             let holder = &option.copyright_holder;
@@ -22,14 +30,7 @@ impl TextRule for HeaderCopyright {
         }
         let re = self.re.as_ref().unwrap();
 
-        if self.linenum.is_none() {
-            self.linenum = Some(0);
-        }
-        if let Some(x) = self.linenum {
-            self.linenum = Some(x+1)
-        }
-
-        if self.linenum.unwrap() == option.copyright_linenum {
+        if self.linenum == option.copyright_linenum {
             let is_match: bool = re.is_match(line);
             if is_match {
                 TextRuleResult::Pass

--- a/src/textrules/header_copyright.rs
+++ b/src/textrules/header_copyright.rs
@@ -1,5 +1,5 @@
 use crate::config::ConfigOption;
-use crate::linter::{TextRule, TextRuleResult};
+use crate::linter::{TextRule, TextRuleEvent, TextRuleResult};
 use regex::Regex;
 
 #[derive(Default)]
@@ -11,14 +11,15 @@ pub struct HeaderCopyright {
 impl TextRule for HeaderCopyright {
     fn check(
         &mut self,
-        line: Option<&str>,
+        event: TextRuleEvent,
         option: &ConfigOption,
     ) -> TextRuleResult {
-        let line: &str = if line.is_none() {
-            self.linenum = 0;
-            return TextRuleResult::Pass;
-        } else {
-            line.unwrap()
+        let line: &str = match event {
+            TextRuleEvent::StartOfFile => {
+                self.linenum = 0;
+                return TextRuleResult::Pass;
+            }
+            TextRuleEvent::Line(x) => x,
         };
         self.linenum += 1;
 

--- a/src/textrules/style_directives.rs
+++ b/src/textrules/style_directives.rs
@@ -1,5 +1,5 @@
 use crate::config::ConfigOption;
-use crate::linter::{TextRule, TextRuleResult};
+use crate::linter::{TextRule, TextRuleEvent, TextRuleResult};
 use regex::Regex;
 
 #[derive(Default)]
@@ -10,13 +10,14 @@ pub struct StyleDirectives {
 impl TextRule for StyleDirectives {
     fn check(
         &mut self,
-        line: Option<&str>,
+        event: TextRuleEvent,
         _option: &ConfigOption,
     ) -> TextRuleResult {
-        let line: &str = if line.is_none() {
-            return TextRuleResult::Pass;
-        } else {
-            line.unwrap()
+        let line: &str = match event {
+            TextRuleEvent::StartOfFile => {
+                return TextRuleResult::Pass;
+            }
+            TextRuleEvent::Line(x) => x,
         };
 
         if self.re.is_none() {

--- a/src/textrules/style_directives.rs
+++ b/src/textrules/style_directives.rs
@@ -10,9 +10,15 @@ pub struct StyleDirectives {
 impl TextRule for StyleDirectives {
     fn check(
         &mut self,
-        line: &str,
+        line: Option<&str>,
         _option: &ConfigOption,
     ) -> TextRuleResult {
+        let line: &str = if line.is_none() {
+            return TextRuleResult::Pass;
+        } else {
+            line.unwrap()
+        };
+
         if self.re.is_none() {
             let keywords =
                 [ "begin_keywords" // {{{

--- a/src/textrules/style_semicolon.rs
+++ b/src/textrules/style_semicolon.rs
@@ -10,9 +10,15 @@ pub struct StyleSemicolon {
 impl TextRule for StyleSemicolon {
     fn check(
         &mut self,
-        line: &str,
+        line: Option<&str>,
         _option: &ConfigOption,
     ) -> TextRuleResult {
+        let line: &str = if line.is_none() {
+            return TextRuleResult::Pass;
+        } else {
+            line.unwrap()
+        };
+
         if self.re.is_none() {
             self.re = Some(Regex::new("([ ]+);").unwrap());
         }

--- a/src/textrules/style_semicolon.rs
+++ b/src/textrules/style_semicolon.rs
@@ -1,5 +1,5 @@
 use crate::config::ConfigOption;
-use crate::linter::{TextRule, TextRuleResult};
+use crate::linter::{TextRule, TextRuleEvent, TextRuleResult};
 use regex::Regex;
 
 #[derive(Default)]
@@ -10,13 +10,14 @@ pub struct StyleSemicolon {
 impl TextRule for StyleSemicolon {
     fn check(
         &mut self,
-        line: Option<&str>,
+        event: TextRuleEvent,
         _option: &ConfigOption,
     ) -> TextRuleResult {
-        let line: &str = if line.is_none() {
-            return TextRuleResult::Pass;
-        } else {
-            line.unwrap()
+        let line: &str = match event {
+            TextRuleEvent::StartOfFile => {
+                return TextRuleResult::Pass;
+            }
+            TextRuleEvent::Line(x) => x,
         };
 
         if self.re.is_none() {

--- a/src/textrules/style_textwidth.rs
+++ b/src/textrules/style_textwidth.rs
@@ -1,5 +1,5 @@
 use crate::config::ConfigOption;
-use crate::linter::{TextRule, TextRuleResult};
+use crate::linter::{TextRule, TextRuleEvent, TextRuleResult};
 
 #[derive(Default)]
 pub struct StyleTextwidth;
@@ -7,13 +7,14 @@ pub struct StyleTextwidth;
 impl TextRule for StyleTextwidth {
     fn check(
         &mut self,
-        line: Option<&str>,
+        event: TextRuleEvent,
         option: &ConfigOption,
     ) -> TextRuleResult {
-        let line: &str = if line.is_none() {
-            return TextRuleResult::Pass;
-        } else {
-            line.unwrap()
+        let line: &str = match event {
+            TextRuleEvent::StartOfFile => {
+                return TextRuleResult::Pass;
+            }
+            TextRuleEvent::Line(x) => x,
         };
 
         let char_indices: Vec<_> = line.char_indices().collect();

--- a/src/textrules/style_textwidth.rs
+++ b/src/textrules/style_textwidth.rs
@@ -7,9 +7,15 @@ pub struct StyleTextwidth;
 impl TextRule for StyleTextwidth {
     fn check(
         &mut self,
-        line: &str,
+        line: Option<&str>,
         option: &ConfigOption,
     ) -> TextRuleResult {
+        let line: &str = if line.is_none() {
+            return TextRuleResult::Pass;
+        } else {
+            line.unwrap()
+        };
+
         let char_indices: Vec<_> = line.char_indices().collect();
         let n_chars = char_indices.len();
         if n_chars > option.textwidth {


### PR DESCRIPTION
- Change/break the API (again, sorry) for textrules.
  After discussion on #257, @skjdbg and I think this is a more flexible solution.
- This change is called Option1 in #257.
- Instead of passing each line as `&str`, pass as `Option<&str>`.
  Rules should interpret `Some(x)` as a line of text, and `None` as a signal that a new item from the list of files is about to be processed.
  This allows textrules to reset (or otherwise update) any internal state machines.
- Found when passing multiple files like `svlint foo.sv bar.sv`, and the textrule `header_copyright` doesn't reset its line counter.
  This change resets the counter before each file is processed.
- This doesn't *require* <https://github.com/dalance/svls/pull/216> to be updated because its `Cargo.toml` is pinned to svlint v0.8.0, but if this accepted, perhaps with another release, I'll update it ASAP.
- Matching (draft) PR for svlint-plugin-sample: <https://github.com/dalance/svlint-plugin-sample/pull/8>
  Needs a new version to pin against before it's mergable.