### PR TITLE
New rules for leading spaces of binary operators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,3 +102,4 @@ under the Developer Certificate of Origin <https://developercertificate.org/>.
 - Andreas K. Berg (@akberg)
 - Damien Pretet (@dpretet)
 - Taichi Ishitani (@taichi-ishitani)
+- Sosuke Hosokawa (@so298)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -9097,7 +9097,7 @@ See also:
 
 ### Hint
 
-Put exact one space before binary boolean operators.
+Put exactly one space before binary arithmetic operators.
 
 ### Reason
 
@@ -9273,7 +9273,7 @@ See also:
 
 ### Hint
 
-Put exact one space before binary boolean operators.
+Put exactly one space before binary boolean operators.
 
 ### Reason
 
@@ -9415,7 +9415,7 @@ See also:
 
 ### Hint
 
-Put exact one space before binary integer operators.
+Put exactly one space before binary integer operators.
 
 ### Reason
 
@@ -11335,6 +11335,9 @@ syntaxrules.style_operator_arithmetic = true
 syntaxrules.style_operator_boolean = true
 syntaxrules.style_operator_integer = true
 syntaxrules.style_operator_unary = true
+syntaxrules.style_operator_arithmetic_leading_space = true
+syntaxrules.style_operator_boolean_leading_space = true
+syntaxrules.style_operator_integer_leading_space = true
 
 syntaxrules.style_keyword_0or1space = true
 syntaxrules.style_keyword_0space = true

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -9083,9 +9083,111 @@ In relation to Annex A of IEEE1800-2017, this rule applies to the specific
 variants of `binary_operator` specified in Table 11-3.
 
 See also:
+
 - **style_operator_boolean** - Suggested companion rule.
 - **style_operator_integer** - Suggested companion rule.
 - **style_operator_unary** - Suggested companion rule.
+- **style_operator_arithmetic_leading_space** - Suggested companion rule. This is the rule for leading whitespace.
+
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+## Syntax Rule: `style_operator_arithmetic_leading_space`
+
+### Hint
+
+Put exact one space before binary operators.
+
+### Reason
+
+Consistent use of whitespace enhances readability by reducing visual noise.
+
+### Pass Example (1 of 1)
+```systemverilog
+module M;
+  localparam int P2 = a + b; // Multiple spaces before `+`.
+
+  // One space before `*`.
+  localparam int P3 = a * b;
+
+  // One space before `**`.
+  localparam int P4 = a ** b;
+
+  // One space before `+`.
+  localparam int P5 = a + b;
+
+  // One space before `%`.
+  localparam int P6 = a % b;
+
+  // One space before `/`.
+  localparam int P7 = a / b;
+
+  // When the previous expression is (`expr`) type
+  localparam int P13 = (a + b) * c;
+endmodule
+```
+
+### Fail Example (1 of 1)
+```systemverilog
+module M;
+  localparam int P2 = a  + b; // Multiple spaces before `+`.
+
+  // No space before `*`.
+  localparam int P3 = a* b;
+
+  // No space before `**`.
+  localparam int P4 = a** b;
+
+  // No space before `+`.
+  localparam int P5 = a+ b;
+
+  // No space before `%`.
+  localparam int P6 = a% b;
+
+  // No space before `/`.
+  localparam int P7 = a/ b;
+
+  // Multiple spaces before `+`.
+  localparam int P8 = a  + b;
+
+  // Multiple spaces before `*`.
+  localparam int P9 = a  * b;
+
+  // Multiple spaces before `**`.
+  localparam int P10 = a  ** b;
+
+  // Multiple spaces before `%`.
+  localparam int P11 = a  % b;
+
+  // Multiple spaces before `/`.
+  localparam int P12 = a  / b;
+
+  // When the previous expression is (`expr`) type
+  localparam int P13 = (a + b)    * c;
+endmodule
+```
+
+### Explanation
+
+This rule checks the leading whitespace immediately following any arithmetic operator:
+`+`
+, `-`
+, `*`
+, `/`
+, `%`
+, and `**`.
+Uses of these operators may have a single space between the
+operator's symbol and the leading symbol or identifier, e.g.
+`a + b`,
+, or `a+b`.
+
+In relation to Annex A of IEEE1800-2017, this rule applies to the specific
+variants of `binary_operator` specified in Table 11-3.
+
+See also:
+
+- **style_operator_arithmetic** - Suggested companion rule. This is the rule for trailing whitespace.
 
 
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -9189,6 +9189,7 @@ See also:
 
 - **style_operator_arithmetic** - Suggested companion rule. This is the rule for trailing whitespace.
 - **style_operator_boolean_leading_space** - Suggested companion rule.
+- **style_operator_integer_leading_space** - Suggested companion rule.
 
 
 
@@ -9331,6 +9332,7 @@ See also:
 
 - **style_operator_boolean** - Suggested companion rule. This is the rule for trailing whitespace.
 - **style_operator_arithmetic_leading_space** - Suggested companion rule.
+- **style_operator_integer_leading_space** - Suggested companion rule.
 
 
 
@@ -9399,9 +9401,70 @@ In relation to Annex A of IEEE1800-2017, this rule applies to specific variants
 of `binary_operator` and `binary_module_path_operator`.
 
 See also:
+
 - **style_operator_arithmetic** - Suggested companion rule.
 - **style_operator_boolean** - Suggested companion rule.
 - **style_operator_unary** - Suggested companion rule.
+- **style_operator_integer_leading_space** - Suggested companion rule. This is the rule for leading whitespace.
+
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+## Syntax Rule: `style_operator_integer_leading_space`
+
+### Hint
+
+Put exact one space before binary integer operators.
+
+### Reason
+
+Consistent use of whitespace enhances readability by reducing visual noise.
+
+### Pass Example (1 of 1)
+```systemverilog
+module M;
+  localparam int P1 = a | b; // Single space around `|`.
+
+  localparam int P2 = a & aMask; // Single space before `&`.
+endmodule
+```
+
+### Fail Example (1 of 1)
+```systemverilog
+module M;
+  localparam int P1 = a|b; // No space around `|`.
+
+  localparam int P2 = a     & aMask; // Multiple spaces before `&`.
+endmodule
+```
+
+### Explanation
+
+This rule checks the whitespace immediately following any binary operator whose
+operation returns an integer (except arithmetic operators):
+`&`
+, `|`
+, `^`
+, `^~`
+, `~^`
+, `>>`
+, `<<`
+, `>>>`
+, and `<<<`.
+Uses of these operators must have single space between the
+operator's symbol and the leading symbol or identifier, e.g.
+`1 << 5`,
+, or `8'hAA | 8'h55`.
+
+In relation to Annex A of IEEE1800-2017, this rule applies to specific variants
+of `binary_operator` and `binary_module_path_operator`.
+
+See also:
+
+- **style_operator_integer** - Suggested companion rule. This is the rule for trailing whitespace.
+- **style_operator_arithmetic_leading_space** - Suggested companion rule.
+- **style_operator_boolean_leading_space** - Suggested companion rule.
 
 
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -9097,7 +9097,7 @@ See also:
 
 ### Hint
 
-Put exact one space before binary operators.
+Put exact one space before binary boolean operators.
 
 ### Reason
 
@@ -9188,6 +9188,7 @@ variants of `binary_operator` specified in Table 11-3.
 See also:
 
 - **style_operator_arithmetic** - Suggested companion rule. This is the rule for trailing whitespace.
+- **style_operator_boolean_leading_space** - Suggested companion rule.
 
 
 
@@ -9257,9 +9258,79 @@ In relation to Annex A of IEEE1800-2017, this rule applies to specific variants
 of `binary_operator` and `binary_module_path_operator`.
 
 See also:
+
 - **style_operator_arithmetic** - Suggested companion rule.
 - **style_operator_integer** - Suggested companion rule.
 - **style_operator_unary** - Suggested companion rule.
+- **style_operator_boolean_leading_space** - Suggestions companion rule. This is the rule for leading whitespace.
+
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+## Syntax Rule: `style_operator_boolean_leading_space`
+
+### Hint
+
+Put exact one space before binary boolean operators.
+
+### Reason
+
+Consistent use of whitespace enhances readability by reducing visual noise.
+
+### Pass Example (1 of 1)
+```systemverilog
+module M;
+  localparam bit P1 = a && b; // One space before `&&`.
+
+  for (genvar i=0; i < 5; i++) begin // One space around `<`.
+  end
+endmodule
+```
+
+### Fail Example (1 of 1)
+```systemverilog
+module M;
+  localparam bit P1 = a&&b; // No space before `&&`.
+
+  localparam bit P2 = a   < b; // Multiple spaces after `<`.
+
+  for (genvar i=0; i<5; i++) begin // No space around `<`.
+  end
+endmodule
+```
+
+### Explanation
+
+This rule checks the whitespace immediately following any binary operator whose
+operation returns a boolean:
+`==`
+, `!=`
+, `===`
+, `!==`
+, `==?`
+, `!=?`
+, `&&`
+, `||`
+, `<`
+, `<=`
+, `>`
+, `>=`
+, `->`
+, and `<->`.
+Uses of these operators must have a single space between the operator's symbol
+and the leading symbol or identifier, e.g.
+`a && b`,
+, `c !== d`
+, or `0 < 5`.
+
+In relation to Annex A of IEEE1800-2017, this rule applies to specific variants
+of `binary_operator` and `binary_module_path_operator`.
+
+See also:
+
+- **style_operator_boolean** - Suggested companion rule. This is the rule for trailing whitespace.
+- **style_operator_arithmetic_leading_space** - Suggested companion rule.
 
 
 

--- a/md/ruleset-style.md
+++ b/md/ruleset-style.md
@@ -219,6 +219,9 @@ syntaxrules.style_operator_arithmetic = true
 syntaxrules.style_operator_boolean = true
 syntaxrules.style_operator_integer = true
 syntaxrules.style_operator_unary = true
+syntaxrules.style_operator_arithmetic_leading_space = true
+syntaxrules.style_operator_boolean_leading_space = true
+syntaxrules.style_operator_integer_leading_space = true
 
 syntaxrules.style_keyword_0or1space = true
 syntaxrules.style_keyword_0space = true

--- a/md/syntaxrules-explanation-style_operator_arithmetic.md
+++ b/md/syntaxrules-explanation-style_operator_arithmetic.md
@@ -14,6 +14,8 @@ In relation to Annex A of IEEE1800-2017, this rule applies to the specific
 variants of `binary_operator` specified in Table 11-3.
 
 See also:
+
 - **style_operator_boolean** - Suggested companion rule.
 - **style_operator_integer** - Suggested companion rule.
 - **style_operator_unary** - Suggested companion rule.
+- **style_operator_arithmetic_leading_space** - Suggested companion rule. This is the rule for leading whitespace.

--- a/md/syntaxrules-explanation-style_operator_arithmetic_leading_space.md
+++ b/md/syntaxrules-explanation-style_operator_arithmetic_leading_space.md
@@ -1,0 +1,18 @@
+This rule checks the leading whitespace immediately following any arithmetic operator:
+`+`
+, `-`
+, `*`
+, `/`
+, `%`
+, and `**`.
+Uses of these operators may have a single space between the
+operator's symbol and the leading symbol or identifier, e.g.
+`a + b`,
+, or `a+b`.
+
+In relation to Annex A of IEEE1800-2017, this rule applies to the specific
+variants of `binary_operator` specified in Table 11-3.
+
+See also:
+
+- **style_operator_arithmetic** - Suggested companion rule. This is the rule for trailing whitespace.

--- a/md/syntaxrules-explanation-style_operator_arithmetic_leading_space.md
+++ b/md/syntaxrules-explanation-style_operator_arithmetic_leading_space.md
@@ -17,3 +17,4 @@ See also:
 
 - **style_operator_arithmetic** - Suggested companion rule. This is the rule for trailing whitespace.
 - **style_operator_boolean_leading_space** - Suggested companion rule.
+- **style_operator_integer_leading_space** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_operator_arithmetic_leading_space.md
+++ b/md/syntaxrules-explanation-style_operator_arithmetic_leading_space.md
@@ -16,3 +16,4 @@ variants of `binary_operator` specified in Table 11-3.
 See also:
 
 - **style_operator_arithmetic** - Suggested companion rule. This is the rule for trailing whitespace.
+- **style_operator_boolean_leading_space** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_operator_boolean_leading_space.md
+++ b/md/syntaxrules-explanation-style_operator_boolean_leading_space.md
@@ -15,7 +15,7 @@ operation returns a boolean:
 , `->`
 , and `<->`.
 Uses of these operators must have a single space between the operator's symbol
-and the following symbol or identifier, e.g.
+and the leading symbol or identifier, e.g.
 `a && b`,
 , `c !== d`
 , or `0 < 5`.
@@ -25,7 +25,5 @@ of `binary_operator` and `binary_module_path_operator`.
 
 See also:
 
-- **style_operator_arithmetic** - Suggested companion rule.
-- **style_operator_integer** - Suggested companion rule.
-- **style_operator_unary** - Suggested companion rule.
-- **style_operator_boolean_leading_space** - Suggestions companion rule. This is the rule for leading whitespace.
+- **style_operator_boolean** - Suggested companion rule. This is the rule for trailing whitespace.
+- **style_operator_arithmetic_leading_space** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_operator_boolean_leading_space.md
+++ b/md/syntaxrules-explanation-style_operator_boolean_leading_space.md
@@ -27,3 +27,4 @@ See also:
 
 - **style_operator_boolean** - Suggested companion rule. This is the rule for trailing whitespace.
 - **style_operator_arithmetic_leading_space** - Suggested companion rule.
+- **style_operator_integer_leading_space** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_operator_integer.md
+++ b/md/syntaxrules-explanation-style_operator_integer.md
@@ -18,6 +18,8 @@ In relation to Annex A of IEEE1800-2017, this rule applies to specific variants
 of `binary_operator` and `binary_module_path_operator`.
 
 See also:
+
 - **style_operator_arithmetic** - Suggested companion rule.
 - **style_operator_boolean** - Suggested companion rule.
 - **style_operator_unary** - Suggested companion rule.
+- **style_operator_integer_leading_space** - Suggested companion rule. This is the rule for leading whitespace.

--- a/md/syntaxrules-explanation-style_operator_integer_leading_space.md
+++ b/md/syntaxrules-explanation-style_operator_integer_leading_space.md
@@ -1,0 +1,24 @@
+This rule checks the whitespace immediately following any binary operator whose
+operation returns an integer (except arithmetic operators):
+`&`
+, `|`
+, `^`
+, `^~`
+, `~^`
+, `>>`
+, `<<`
+, `>>>`
+, and `<<<`.
+Uses of these operators must have single space between the
+operator's symbol and the leading symbol or identifier, e.g.
+`1 << 5`,
+, or `8'hAA | 8'h55`.
+
+In relation to Annex A of IEEE1800-2017, this rule applies to specific variants
+of `binary_operator` and `binary_module_path_operator`.
+
+See also:
+
+- **style_operator_integer** - Suggested companion rule. This is the rule for trailing whitespace.
+- **style_operator_arithmetic_leading_space** - Suggested companion rule.
+- **style_operator_boolean_leading_space** - Suggested companion rule.

--- a/rulesets/style.toml
+++ b/rulesets/style.toml
@@ -12,6 +12,9 @@ syntaxrules.style_operator_arithmetic = true
 syntaxrules.style_operator_boolean = true
 syntaxrules.style_operator_integer = true
 syntaxrules.style_operator_unary = true
+syntaxrules.style_operator_arithmetic_leading_space = true
+syntaxrules.style_operator_boolean_leading_space = true
+syntaxrules.style_operator_integer_leading_space = true
 
 syntaxrules.style_keyword_0or1space = true
 syntaxrules.style_keyword_0space = true

--- a/src/syntaxrules/style_operator_arithmetic_leading_space.rs
+++ b/src/syntaxrules/style_operator_arithmetic_leading_space.rs
@@ -70,7 +70,7 @@ impl SyntaxRule for StyleOperatorArithmeticLeadingSpace {
     }
 
     fn hint(&self, _option: &ConfigOption) -> String {
-        String::from(format!("Put exact one space before binary boolean operators."))
+        String::from(format!("Put exact one space before binary arithmetic operators."))
     }
 
     fn reason(&self) -> String {

--- a/src/syntaxrules/style_operator_arithmetic_leading_space.rs
+++ b/src/syntaxrules/style_operator_arithmetic_leading_space.rs
@@ -1,0 +1,100 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{NodeEvent, RefNode, SyntaxTree};
+
+pub struct StyleOperatorArithmeticLeadingSpace {
+    /// Number of trailing spaces of the previous node
+    prev_trailing_space: usize,
+
+    /// True if the previous node is an `Expression`
+    prev_is_expr: bool,
+}
+
+impl SyntaxRule for StyleOperatorArithmeticLeadingSpace {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        match event {
+            NodeEvent::Enter(node) => {
+                if !self.prev_is_expr {
+                    return SyntaxRuleResult::Pass;
+                }
+
+                match node {
+                    RefNode::BinaryOperator(x) => {
+                        let t = syntax_tree.get_str_trim(*x).unwrap();
+                        
+                        match t {
+                            "+" | "-" | "*" | "/" | "%" | "**" => {
+                                if self.prev_trailing_space == 1 {
+                                    SyntaxRuleResult::Pass
+                                } else {
+                                    SyntaxRuleResult::Fail
+                                }
+                            }
+                            _ => SyntaxRuleResult::Pass,
+                        }
+                    }
+                    _ => SyntaxRuleResult::Pass,
+                }
+            }
+            NodeEvent::Leave(node) => {
+                match node {
+                    RefNode::Expression(expr) => {
+                        self.prev_is_expr = true;
+                        let trailing_space =
+                            count_trailing_space(syntax_tree.get_str(*expr).unwrap());
+                        self.prev_trailing_space = trailing_space;
+                    }
+                    RefNode::ConstantExpression(expr) => {
+                        self.prev_is_expr = true;
+                        let trailing_space =
+                            count_trailing_space(syntax_tree.get_str(*expr).unwrap());
+                        self.prev_trailing_space = trailing_space;
+                    }
+                    _ => {
+                        self.prev_is_expr = false;
+                        self.prev_trailing_space = 0;
+                    }
+                }
+                SyntaxRuleResult::Pass
+            }
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("style_operator_arithmetic_leading_space")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from(format!("Put exact one space before binary boolean operators."))
+    }
+
+    fn reason(&self) -> String {
+        String::from("Consistent use of whitespace enhances readability by reducing visual noise.")
+    }
+}
+
+fn count_trailing_space(s: &str) -> usize {
+    let mut count = 0;
+    for c in s.chars().rev() {
+        if c == ' ' {
+            count += 1;
+        } else {
+            break;
+        }
+    }
+    count
+}
+
+impl std::default::Default for StyleOperatorArithmeticLeadingSpace {
+    fn default() -> Self {
+        Self {
+            prev_trailing_space: 0,
+            prev_is_expr: false,
+        }
+    }
+}

--- a/src/syntaxrules/style_operator_arithmetic_leading_space.rs
+++ b/src/syntaxrules/style_operator_arithmetic_leading_space.rs
@@ -70,7 +70,7 @@ impl SyntaxRule for StyleOperatorArithmeticLeadingSpace {
     }
 
     fn hint(&self, _option: &ConfigOption) -> String {
-        String::from(format!("Put exact one space before binary arithmetic operators."))
+        String::from(format!("Put exactly one space before binary arithmetic operators."))
     }
 
     fn reason(&self) -> String {

--- a/src/syntaxrules/style_operator_boolean_leading_space.rs
+++ b/src/syntaxrules/style_operator_boolean_leading_space.rs
@@ -1,0 +1,101 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{NodeEvent, RefNode, SyntaxTree};
+
+pub struct StyleOperatorBooleanLeadingSpace {
+    /// Number of trailing spaces of the previous node
+    prev_trailing_space: usize,
+
+    /// True if the previous node is an `Expression`
+    prev_is_expr: bool,
+}
+
+impl SyntaxRule for StyleOperatorBooleanLeadingSpace {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        match event {
+            NodeEvent::Enter(node) => {
+                if !self.prev_is_expr {
+                    return SyntaxRuleResult::Pass;
+                }
+
+                match node {
+                    RefNode::BinaryOperator(x) => {
+                        let t = syntax_tree.get_str_trim(*x).unwrap();
+
+                        match t {
+                            "==" | "!=" | "<" | ">" | "<=" | ">=" | "&&" | "||" | "===" | "==?"
+                            | "!==" | "!=?" | "->" | "<->" => {
+                                if self.prev_trailing_space == 1 {
+                                    SyntaxRuleResult::Pass
+                                } else {
+                                    SyntaxRuleResult::Fail
+                                }
+                            }
+                            _ => SyntaxRuleResult::Pass,
+                        }
+                    }
+                    _ => SyntaxRuleResult::Pass,
+                }
+            }
+            NodeEvent::Leave(node) => {
+                match node {
+                    RefNode::Expression(expr) => {
+                        self.prev_is_expr = true;
+                        let trailing_space =
+                            count_trailing_space(syntax_tree.get_str(*expr).unwrap());
+                        self.prev_trailing_space = trailing_space;
+                    }
+                    RefNode::ConstantExpression(expr) => {
+                        self.prev_is_expr = true;
+                        let trailing_space =
+                            count_trailing_space(syntax_tree.get_str(*expr).unwrap());
+                        self.prev_trailing_space = trailing_space;
+                    }
+                    _ => {
+                        self.prev_is_expr = false;
+                        self.prev_trailing_space = 0;
+                    }
+                }
+                SyntaxRuleResult::Pass
+            }
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("style_operator_boolean_leading_space")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from(format!("Put exact one space before binary boolean operators."))
+    }
+
+    fn reason(&self) -> String {
+        String::from("Consistent use of whitespace enhances readability by reducing visual noise.")
+    }
+}
+
+fn count_trailing_space(s: &str) -> usize {
+    let mut count = 0;
+    for c in s.chars().rev() {
+        if c == ' ' {
+            count += 1;
+        } else {
+            break;
+        }
+    }
+    count
+}
+
+impl std::default::Default for StyleOperatorBooleanLeadingSpace {
+    fn default() -> Self {
+        Self {
+            prev_trailing_space: 0,
+            prev_is_expr: false,
+        }
+    }
+}

--- a/src/syntaxrules/style_operator_boolean_leading_space.rs
+++ b/src/syntaxrules/style_operator_boolean_leading_space.rs
@@ -71,7 +71,7 @@ impl SyntaxRule for StyleOperatorBooleanLeadingSpace {
     }
 
     fn hint(&self, _option: &ConfigOption) -> String {
-        String::from(format!("Put exact one space before binary boolean operators."))
+        String::from(format!("Put exactly one space before binary boolean operators."))
     }
 
     fn reason(&self) -> String {

--- a/src/syntaxrules/style_operator_integer_leading_space.rs
+++ b/src/syntaxrules/style_operator_integer_leading_space.rs
@@ -71,7 +71,7 @@ impl SyntaxRule for StyleOperatorIntegerLeadingSpace {
 
     fn hint(&self, _option: &ConfigOption) -> String {
         String::from(format!(
-            "Put exact one space before binary integer operators."
+            "Put exactly one space before binary integer operators."
         ))
     }
 

--- a/src/syntaxrules/style_operator_integer_leading_space.rs
+++ b/src/syntaxrules/style_operator_integer_leading_space.rs
@@ -1,0 +1,102 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{NodeEvent, RefNode, SyntaxTree};
+
+pub struct StyleOperatorIntegerLeadingSpace {
+    /// Number of trailing spaces of the previous node
+    prev_trailing_space: usize,
+
+    /// True if the previous node is an `Expression`
+    prev_is_expr: bool,
+}
+
+impl SyntaxRule for StyleOperatorIntegerLeadingSpace {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        match event {
+            NodeEvent::Enter(node) => {
+                if !self.prev_is_expr {
+                    return SyntaxRuleResult::Pass;
+                }
+
+                match node {
+                    RefNode::BinaryOperator(x) => {
+                        let t = syntax_tree.get_str_trim(*x).unwrap();
+
+                        match t {
+                            "&" | "|" | "^" | "^~" | "~^" | ">>" | "<<" | ">>>" | "<<<" => {
+                                if self.prev_trailing_space == 1 {
+                                    SyntaxRuleResult::Pass
+                                } else {
+                                    SyntaxRuleResult::Fail
+                                }
+                            }
+                            _ => SyntaxRuleResult::Pass,
+                        }
+                    }
+                    _ => SyntaxRuleResult::Pass,
+                }
+            }
+            NodeEvent::Leave(node) => {
+                match node {
+                    RefNode::Expression(expr) => {
+                        self.prev_is_expr = true;
+                        let trailing_space =
+                            count_trailing_space(syntax_tree.get_str(*expr).unwrap());
+                        self.prev_trailing_space = trailing_space;
+                    }
+                    RefNode::ConstantExpression(expr) => {
+                        self.prev_is_expr = true;
+                        let trailing_space =
+                            count_trailing_space(syntax_tree.get_str(*expr).unwrap());
+                        self.prev_trailing_space = trailing_space;
+                    }
+                    _ => {
+                        self.prev_is_expr = false;
+                        self.prev_trailing_space = 0;
+                    }
+                }
+                SyntaxRuleResult::Pass
+            }
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("style_operator_integer_leading_space")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from(format!(
+            "Put exact one space before binary integer operators."
+        ))
+    }
+
+    fn reason(&self) -> String {
+        String::from("Consistent use of whitespace enhances readability by reducing visual noise.")
+    }
+}
+
+fn count_trailing_space(s: &str) -> usize {
+    let mut count = 0;
+    for c in s.chars().rev() {
+        if c == ' ' {
+            count += 1;
+        } else {
+            break;
+        }
+    }
+    count
+}
+
+impl std::default::Default for StyleOperatorIntegerLeadingSpace {
+    fn default() -> Self {
+        Self {
+            prev_trailing_space: 0,
+            prev_is_expr: false,
+        }
+    }
+}

--- a/testcases/syntaxrules/fail/style_operator_arithmetic_leading_space.sv
+++ b/testcases/syntaxrules/fail/style_operator_arithmetic_leading_space.sv
@@ -1,0 +1,36 @@
+module M;
+  localparam int P2 = a  + b; // Multiple spaces before `+`.
+
+  // No space before `*`.
+  localparam int P3 = a* b;
+
+  // No space before `**`.
+  localparam int P4 = a** b;
+
+  // No space before `+`.
+  localparam int P5 = a+ b;
+
+  // No space before `%`.
+  localparam int P6 = a% b;
+
+  // No space before `/`.
+  localparam int P7 = a/ b;
+
+  // Multiple spaces before `+`.
+  localparam int P8 = a  + b;
+
+  // Multiple spaces before `*`.
+  localparam int P9 = a  * b;
+
+  // Multiple spaces before `**`.
+  localparam int P10 = a  ** b;
+
+  // Multiple spaces before `%`.
+  localparam int P11 = a  % b;
+
+  // Multiple spaces before `/`.
+  localparam int P12 = a  / b;
+
+  // When the previous expression is (`expr`) type
+  localparam int P13 = (a + b)    * c;
+endmodule

--- a/testcases/syntaxrules/fail/style_operator_boolean_leading_space.sv
+++ b/testcases/syntaxrules/fail/style_operator_boolean_leading_space.sv
@@ -1,0 +1,8 @@
+module M;
+  localparam bit P1 = a&&b; // No space before `&&`.
+
+  localparam bit P2 = a   < b; // Multiple spaces after `<`.
+
+  for (genvar i=0; i<5; i++) begin // No space around `<`.
+  end
+endmodule

--- a/testcases/syntaxrules/fail/style_operator_integer_leading_space.sv
+++ b/testcases/syntaxrules/fail/style_operator_integer_leading_space.sv
@@ -1,0 +1,5 @@
+module M;
+  localparam int P1 = a|b; // No space around `|`.
+
+  localparam int P2 = a     & aMask; // Multiple spaces before `&`.
+endmodule

--- a/testcases/syntaxrules/pass/style_operator_arithmetic_leading_space.sv
+++ b/testcases/syntaxrules/pass/style_operator_arithmetic_leading_space.sv
@@ -1,0 +1,21 @@
+module M;
+  localparam int P2 = a + b; // Multiple spaces before `+`.
+
+  // One space before `*`.
+  localparam int P3 = a * b;
+
+  // One space before `**`.
+  localparam int P4 = a ** b;
+
+  // One space before `+`.
+  localparam int P5 = a + b;
+
+  // One space before `%`.
+  localparam int P6 = a % b;
+
+  // One space before `/`.
+  localparam int P7 = a / b;
+
+  // When the previous expression is (`expr`) type
+  localparam int P13 = (a + b) * c;
+endmodule

--- a/testcases/syntaxrules/pass/style_operator_boolean_leading_space.sv
+++ b/testcases/syntaxrules/pass/style_operator_boolean_leading_space.sv
@@ -1,0 +1,6 @@
+module M;
+  localparam bit P1 = a && b; // One space before `&&`.
+
+  for (genvar i=0; i < 5; i++) begin // One space around `<`.
+  end
+endmodule

--- a/testcases/syntaxrules/pass/style_operator_integer_leading_space.sv
+++ b/testcases/syntaxrules/pass/style_operator_integer_leading_space.sv
@@ -1,0 +1,5 @@
+module M;
+  localparam int P1 = a | b; // Single space around `|`.
+
+  localparam int P2 = a & aMask; // Single space before `&`.
+endmodule


### PR DESCRIPTION
Hi, @dalance!

I added some new rules for **leading spaces** of binary operators.
The names of the new rules are the following:

- `style_operator_arithmetic_leading_space`
- `style_operator_boolean_leading_space`
- `style_operator_integer_leading_space`

Each of these rules corresponds to the following existing rules.

- `style_operator_arithmetic`
- `style_operator_boolean`
- `style_operator_integer`

These existing rules are for the number of following spaces and do not support leading spaces.

For example:

When I give the following SystemVerilog code to the linter with `style_operator_arithmetic` rule enabled, 
```sv
module M;
  localparam int P2 = a  + b; // Multiple spaces before `+`.

  // No space before `*`.
  localparam int P3 = a* b;

endmodule
```

I expect the result that says the numbers of the leading spaces of `*` and `+` operators are not appropriate, but no message will be found actually because this existing rule do not consider leading space.

With the new rules I implemeted, this message will be found for the sample code.

```log
Fail: style_operator_arithmetic_leading_space
   --> test.sv:2:26
  |
2 |   localparam int P2 = a  + b; // Multiple spaces before `+`.
  |                          ^ hint  : Put exact one space before binary arithmetic operators.
  |                            reason: Consistent use of whitespace enhances readability by reducing visual noise.

Fail: style_operator_arithmetic_leading_space
   --> test.sv:5:24
  |
5 |   localparam int P3 = a* b;
  |                        ^ hint  : Put exact one space before binary arithmetic operators.
  |                          reason: Consistent use of whitespace enhances readability by reducing visual noise.
```

The new rules only consider the number of leading spaces. (do not consider following spaces)