### PR TITLE
New Rule: Implicit case default

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2042,7 +2042,7 @@ Signal driven in `case` statement does not have a default value.
 
 Default values ensure that signals are always driven.
 
-### Pass Example (1 of 2)
+### Pass Example (1 of 3)
 ```systemverilog
 module M;
   always_comb
@@ -2053,7 +2053,25 @@ module M;
 endmodule
 ```
 
-### Pass Example (2 of 2)
+### Pass Example (2 of 3)
+```systemverilog
+module M;
+  always_comb begin
+    y = 0;
+    z = 0;
+    w = 0;
+    case(x)
+      1: y = 1;
+      2: begin 
+        z = 1;
+        w = 1;
+      end
+    endcase
+  end
+endmodule
+```
+
+### Pass Example (3 of 3)
 ```systemverilog
 module M;
   always_comb
@@ -2064,7 +2082,7 @@ module M;
 endmodule
 ```
 
-### Fail Example (1 of 2)
+### Fail Example (1 of 3)
 ```systemverilog
 module M;
   always_comb
@@ -2074,12 +2092,27 @@ module M;
 endmodule
 ```
 
-### Fail Example (2 of 2)
+### Fail Example (2 of 3)
+```systemverilog
+module M;
+  always_comb begin
+    y = 0;
+    case(x)
+      1: y = 1;
+      2: begin 
+        z = 1;
+        w = 1;
+      end
+    endcase
+  end
+endmodule
+```
+
+### Fail Example (3 of 3)
 ```systemverilog
 module M;
   always_comb begin
     a = 0;
-
     case(x)
       1: b = 0;
     endcase

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2154,8 +2154,11 @@ endmodule
 
 ### Explanation
 
-This rule is an extension of the **case_default** rule that allows the case default to be implicitly defined.
-Case statements without a `default` branch can cause signals to be undriven. Setting default values of signals at the top of an `always` procedures is good practice and ensures that signals are never metastable when a case match fails. For example,
+This rule is an extension of the **case_default** rule that allows the case
+default to be implicitly defined. Case statements without a `default` branch
+can cause signals to be undriven. Setting default values of signals at the top
+of an `always` procedures is good practice and ensures that signals are never
+metastable when a case match fails. For example,
 ```sv
 always_comb begin
   y = 0;
@@ -2165,14 +2168,14 @@ always_comb begin
 end
 
 ```
-If the case match fails, `y` wouldn't infer memory or be undriven because the default value is defined before the `case`.
+If the case match fails, `y` wouldn't infer memory or be undriven because the
+default value is defined before the `case`.
 
 See also:
  - **case_default**
  - **explicit_case_default**
 
 The most relevant clauses of IEEE1800-2017 are:
-
 - 12.5 Case statement
 
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2040,29 +2040,30 @@ Signal driven in `case` statement does not have a default value.
 
 ### Reason
 
-Default values ensure that signals are always driven.
+Default values ensure that signals are never metastable.
 
-### Pass Example (1 of 3)
+### Pass Example (1 of 5)
 ```systemverilog
 module M;
-  always_comb
+  always_comb begin
     y = 0;
-    case(x)
+    case (x)
       1: y = 1; // case default is implicit
     endcase
+  end
 endmodule
 ```
 
-### Pass Example (2 of 3)
+### Pass Example (2 of 5)
 ```systemverilog
 module M;
   always_comb begin
     y = 0;
     z = 0;
     w = 0;
-    case(x)
+    case (x)
       1: y = 1;
-      2: begin 
+      2: begin
         z = 1;
         w = 1;
       end
@@ -2071,14 +2072,45 @@ module M;
 endmodule
 ```
 
-### Pass Example (3 of 3)
+### Pass Example (3 of 5)
 ```systemverilog
 module M;
   always_comb
-    case(x)
+    case (x)
       1: y = 1;
       default: y = 0;
     endcase
+endmodule
+```
+
+### Pass Example (4 of 5)
+```systemverilog
+module M;
+  always_comb
+    case (x)
+      1: p = 1;
+      2: q = 0;
+      default: begin
+        p = 0;
+        q = 0;
+      end
+    endcase
+endmodule
+```
+
+### Pass Example (5 of 5)
+```systemverilog
+module M;
+  always_comb begin
+    p = 0;  // p -> implicit default
+    q = 0;  // q -> implicit default
+    case (x)
+      1: p = 1;
+      2: q = 1;
+      3: r = 1;
+      default: r = 1; // r -> explicit default
+    endcase
+  end
 endmodule
 ```
 
@@ -2097,9 +2129,9 @@ endmodule
 module M;
   always_comb begin
     y = 0;
-    case(x)
+    case (x)
       1: y = 1;
-      2: begin 
+      2: begin
         z = 1;
         w = 1;
       end
@@ -2113,7 +2145,7 @@ endmodule
 module M;
   always_comb begin
     a = 0;
-    case(x)
+    case (x)
       1: b = 0;
     endcase
   end

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2159,25 +2159,37 @@ default to be implicitly defined. Case statements without a `default` branch
 can cause signals to be undriven. Setting default values of signals at the top
 of an `always` procedures is good practice and ensures that signals are never
 metastable when a case match fails. For example,
+
 ```sv
 always_comb begin
   y = 0;
-  case(x)
+  case (x)
     1: y = 1;
   endcase
 end
 
 ```
-If the case match fails, `y` wouldn't infer memory or be undriven because the
-default value is defined before the `case`.
+
+If the case match on `x` fails, `y` would not infer memory or be undriven
+because the default value is defined before the `case`.
+
+This rule is a more lenient version of `case_default`. It adapts to a specific
+coding style of setting default values to signals at the top of a procedural
+block to ensure that signals have a default value regardless of the logic in the
+procedural block. As such, this rule will only consider values set
+**unconditionally** at the top of the procedural block as a default and will
+disregard assignments made in conditional blocks like `if`/`else`, etc. If this
+coding style is not preferred, it is strongly suggested to use the rules
+mentioned below as they offer stricter guarantees.
 
 See also:
- - **case_default**
- - **explicit_case_default**
+
+- **case_default**
+- **explicit_case_default**
 
 The most relevant clauses of IEEE1800-2017 are:
-- 12.5 Case statement
 
+- 12.5 Case statement
 
 
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2032,6 +2032,89 @@ The most relevant clauses of IEEE1800-2017 are:
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
+## Syntax Rule: `implicit_case_default`
+
+### Hint
+
+Signal driven in `case` statement does not have a default value.
+
+### Reason
+
+Default values ensure that signals are always driven.
+
+### Pass Example (1 of 2)
+```systemverilog
+module M;
+  always_comb
+    y = 0;
+    case(x)
+      1: y = 1; // case default is implicit
+    endcase
+endmodule
+```
+
+### Pass Example (2 of 2)
+```systemverilog
+module M;
+  always_comb
+    case(x)
+      1: y = 1;
+      default: y = 0;
+    endcase
+endmodule
+```
+
+### Fail Example (1 of 2)
+```systemverilog
+module M;
+  always_comb
+    case (x)
+      1: a = 0; // No implicit or explicit case default
+    endcase
+endmodule
+```
+
+### Fail Example (2 of 2)
+```systemverilog
+module M;
+  always_comb begin
+    a = 0;
+
+    case(x)
+      1: b = 0;
+    endcase
+  end
+endmodule
+```
+
+### Explanation
+
+This rule is an extension of the **case_default** rule that allows the case default to be implicitly defined.
+Case statements without a `default` branch can cause signals to be undriven. Setting default values of signals at the top of an `always` procedures is good practice and ensures that signals are never metastable when a case match fails. For example,
+```sv
+always_comb begin
+  y = 0;
+  case(x)
+    1: y = 1;
+  endcase
+end
+
+```
+If the case match fails, `y` wouldn't infer memory or be undriven because the default value is defined before the `case`.
+
+See also:
+ - **case_default**
+ - **explicit_case_default**
+
+The most relevant clauses of IEEE1800-2017 are:
+
+- 12.5 Case statement
+
+
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
 ## Syntax Rule: `inout_with_tri`
 
 ### Hint

--- a/md/syntaxrules-explanation-implicit_case_default.md
+++ b/md/syntaxrules-explanation-implicit_case_default.md
@@ -14,3 +14,8 @@ If the case match fails, `y` wouldn't infer memory or be undriven because the de
 See also:
  - **case_default**
  - **explicit_case_default**
+
+The most relevant clauses of IEEE1800-2017 are:
+
+- 12.5 Case statement
+

--- a/md/syntaxrules-explanation-implicit_case_default.md
+++ b/md/syntaxrules-explanation-implicit_case_default.md
@@ -3,22 +3,34 @@ default to be implicitly defined. Case statements without a `default` branch
 can cause signals to be undriven. Setting default values of signals at the top
 of an `always` procedures is good practice and ensures that signals are never
 metastable when a case match fails. For example,
+
 ```sv
 always_comb begin
   y = 0;
-  case(x)
+  case (x)
     1: y = 1;
   endcase
 end
 
 ```
-If the case match fails, `y` wouldn't infer memory or be undriven because the
-default value is defined before the `case`.
+
+If the case match on `x` fails, `y` would not infer memory or be undriven
+because the default value is defined before the `case`.
+
+This rule is a more lenient version of `case_default`. It adapts to a specific
+coding style of setting default values to signals at the top of a procedural
+block to ensure that signals have a default value regardless of the logic in the
+procedural block. As such, this rule will only consider values set
+**unconditionally** at the top of the procedural block as a default and will
+disregard assignments made in conditional blocks like `if`/`else`, etc. If this
+coding style is not preferred, it is strongly suggested to use the rules
+mentioned below as they offer stricter guarantees.
 
 See also:
- - **case_default**
- - **explicit_case_default**
+
+- **case_default**
+- **explicit_case_default**
 
 The most relevant clauses of IEEE1800-2017 are:
-- 12.5 Case statement
 
+- 12.5 Case statement

--- a/md/syntaxrules-explanation-implicit_case_default.md
+++ b/md/syntaxrules-explanation-implicit_case_default.md
@@ -1,5 +1,8 @@
-This rule is an extension of the **case_default** rule that allows the case default to be implicitly defined.
-Case statements without a `default` branch can cause signals to be undriven. Setting default values of signals at the top of an `always` procedures is good practice and ensures that signals are never metastable when a case match fails. For example,
+This rule is an extension of the **case_default** rule that allows the case
+default to be implicitly defined. Case statements without a `default` branch
+can cause signals to be undriven. Setting default values of signals at the top
+of an `always` procedures is good practice and ensures that signals are never
+metastable when a case match fails. For example,
 ```sv
 always_comb begin
   y = 0;
@@ -9,13 +12,13 @@ always_comb begin
 end
 
 ```
-If the case match fails, `y` wouldn't infer memory or be undriven because the default value is defined before the `case`.
+If the case match fails, `y` wouldn't infer memory or be undriven because the
+default value is defined before the `case`.
 
 See also:
  - **case_default**
  - **explicit_case_default**
 
 The most relevant clauses of IEEE1800-2017 are:
-
 - 12.5 Case statement
 

--- a/md/syntaxrules-explanation-implicit_case_default.md
+++ b/md/syntaxrules-explanation-implicit_case_default.md
@@ -1,0 +1,16 @@
+This rule is an extension of the **case_default** rule that allows the case default to be implicitly defined.
+Case statements without a `default` branch can cause signals to be undriven. Setting default values of signals at the top of an `always` procedures is good practice and ensures that signals are never metastable when a case match fails. For example,
+```sv
+always_comb begin
+  y = 0;
+  case(x)
+    1: y = 1;
+  endcase
+end
+
+```
+If the case match fails, `y` wouldn't infer memory or be undriven because the default value is defined before the `case`.
+
+See also:
+ - **case_default**
+ - **explicit_case_default**

--- a/src/syntaxrules/implicit_case_default.rs
+++ b/src/syntaxrules/implicit_case_default.rs
@@ -1,13 +1,12 @@
 use crate::config::ConfigOption;
 use crate::linter::{SyntaxRule, SyntaxRuleResult};
-use sv_parser::{unwrap_node, Locate, NodeEvent, RefNode, SyntaxTree};
+use sv_parser::{unwrap_locate, unwrap_node, NodeEvent, RefNode, SyntaxTree};
 
 #[derive(Default)]
 pub struct ImplicitCaseDefault {
     under_always_construct: bool,
     under_case_item: bool,
-    is_default: bool,
-
+    has_default: bool,
     lhs_variables: Vec<String>,
 }
 
@@ -23,13 +22,13 @@ impl SyntaxRule for ImplicitCaseDefault {
                 match x {
                     RefNode::AlwaysConstruct(_) => {
                         self.under_always_construct = true;
-                        self.is_default = false;
+                        self.has_default = false;
                     }
 
                     RefNode::CaseItemNondefault(_) => {
                         self.under_case_item = true;
                     }
-                    
+
                     _ => (),
                 }
                 x
@@ -39,7 +38,7 @@ impl SyntaxRule for ImplicitCaseDefault {
                 match x {
                     RefNode::AlwaysConstruct(_) => {
                         self.under_always_construct = false;
-                        self.is_default = false;
+                        self.has_default = false;
                         self.lhs_variables.clear();
                     }
 
@@ -47,66 +46,59 @@ impl SyntaxRule for ImplicitCaseDefault {
                         self.under_case_item = false;
                     }
 
-                    _ => ()
+                    _ => (),
                 }
                 return SyntaxRuleResult::Pass;
             }
         };
 
         // match implicit declarations
-        match (self.under_always_construct, self.under_case_item, node) {
-            (true, false, RefNode::BlockItemDeclaration(x)) => {
-                let var = unwrap_node!(*x, VariableDeclAssignment).unwrap();
-                let id = get_identifier(var);
-                let id = syntax_tree.get_str(&id).unwrap();
-                self.lhs_variables.push(String::from(id));
-            }
-
-            _ => ()
+        if let (true, false, RefNode::BlockItemDeclaration(x)) =
+            (self.under_always_construct, self.under_case_item, node)
+        {
+            let var = unwrap_node!(*x, VariableDeclAssignment).unwrap();
+            let id = get_identifier(var, syntax_tree);
+            self.lhs_variables.push(id);
         }
 
         // check if default
-        match (self.under_always_construct, node) {
-            (true, RefNode::CaseStatementNormal(x)) => {
-                let a = unwrap_node!(*x, CaseItemDefault);
-                if a.is_some() {
-                    self.is_default = true;
-                }
+        if let (true, RefNode::CaseStatementNormal(x)) = (self.under_always_construct, node) {
+            let a = unwrap_node!(*x, CaseItemDefault);
+            if a.is_some() {
+                self.has_default = true;
             }
-
-            _ => ()
         }
 
         // match case statement declarations
         match (self.under_always_construct, self.under_case_item, node) {
             (true, true, RefNode::BlockingAssignment(x)) => {
                 let var = unwrap_node!(*x, VariableLvalueIdentifier).unwrap();
-                let id = get_identifier(var);
-                let id = syntax_tree.get_str(&id).unwrap();
-                
-                if self.lhs_variables.contains(&id.to_string()) || self.is_default {
-                    return SyntaxRuleResult::Pass
+                let loc = unwrap_locate!(var.clone()).unwrap();
+                let id = get_identifier(var, syntax_tree);
+
+                if self.lhs_variables.contains(&id.to_string()) || self.has_default {
+                    return SyntaxRuleResult::Pass;
                 } else {
-                    return SyntaxRuleResult::Fail
+                    return SyntaxRuleResult::FailLocate(*loc);
                 }
             }
-            
+
             (true, true, RefNode::BlockItemDeclaration(x)) => {
                 let var = unwrap_node!(*x, VariableDeclAssignment).unwrap();
-                let id = get_identifier(var);
-                let id = syntax_tree.get_str(&id).unwrap();
-               
-                if self.lhs_variables.contains(&id.to_string()) || self.is_default {
-                    return SyntaxRuleResult::Pass
+                let loc = unwrap_locate!(var.clone()).unwrap();
+                let id = get_identifier(var, syntax_tree);
+
+                if self.lhs_variables.contains(&id.to_string()) || self.has_default {
+                    return SyntaxRuleResult::Pass;
                 } else {
-                    return SyntaxRuleResult::Fail
+                    return SyntaxRuleResult::FailLocate(*loc);
                 }
             }
-            
-            _ => ()
+
+            _ => (),
         }
 
-        return SyntaxRuleResult::Pass
+        SyntaxRuleResult::Pass
     }
 
     fn name(&self) -> String {
@@ -118,14 +110,16 @@ impl SyntaxRule for ImplicitCaseDefault {
     }
 
     fn reason(&self) -> String {
-        String::from("Default values ensure that signals are always driven.")
+        String::from("Default values ensure that signals are never metastable.")
     }
 }
 
-fn get_identifier(node: RefNode) -> Option<Locate> {
-    match unwrap_node!(node, SimpleIdentifier, EscapedIdentifier) {
+fn get_identifier(node: RefNode, syntax_tree: &SyntaxTree) -> String {
+    let id = match unwrap_node!(node, SimpleIdentifier, EscapedIdentifier) {
         Some(RefNode::SimpleIdentifier(x)) => Some(x.nodes.0),
         Some(RefNode::EscapedIdentifier(x)) => Some(x.nodes.0),
         _ => None,
-    }
+    };
+
+    String::from(syntax_tree.get_str(&id).unwrap())
 }

--- a/src/syntaxrules/implicit_case_default.rs
+++ b/src/syntaxrules/implicit_case_default.rs
@@ -1,0 +1,92 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{unwrap_node, Locate, NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct ImplicitCaseDefault {
+    under_always_construct: bool,
+    lhs_variables: Vec<String>,
+}
+
+impl SyntaxRule for ImplicitCaseDefault {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        // println!("Syntax Tree: {}", syntax_tree);
+
+        let node = match event {
+            NodeEvent::Enter(x) => {
+                match x {
+                    RefNode::AlwaysConstruct(_) => {
+                        self.under_always_construct = true;
+                    }
+
+                    RefNode::BlockItemDeclaration(x) => {
+                        let var = unwrap_node!(*x, VariableDeclAssignment).unwrap();
+                        let id = get_identifier(var);
+                        let id = syntax_tree.get_str(&id).unwrap();
+
+                        self.lhs_variables.push(String::from(id));
+
+                        println!("LHS Variables: {:?}", self.lhs_variables);
+                    }
+
+                    _ => (),
+                }
+                x
+            }
+            NodeEvent::Leave(x) => {
+                if let RefNode::AlwaysConstruct(_) = x {
+                    self.under_always_construct = false;
+                }
+                return SyntaxRuleResult::Pass;
+            }
+        };
+        match (self.under_always_construct, node) {
+            (true, RefNode::CaseStatementNormal(x)) => {
+                let a = unwrap_node!(*x, CaseItemDefault);
+                if a.is_some() {
+                    SyntaxRuleResult::Pass
+                } else {
+                    // check if lvalues of case statement have an implicit definition
+                    let var = unwrap_node!(*x, VariableLvalueIdentifier).unwrap();
+                    let id = get_identifier(var);
+                    let id = syntax_tree.get_str(&id).unwrap();
+
+                    println!("Case variable: {id}");
+
+                    // check if id is in lhs_variables
+                    if self.lhs_variables.contains(&id.to_string()) {
+                        SyntaxRuleResult::Pass
+                    } else {
+                        SyntaxRuleResult::Fail
+                    }
+                }
+            }
+            _ => SyntaxRuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("implicit_case_default")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("Signal driven in `case` statement does not have a default value.")
+    }
+
+    fn reason(&self) -> String {
+        String::from("Default values ensure that signals are always driven.")
+    }
+}
+
+fn get_identifier(node: RefNode) -> Option<Locate> {
+    match unwrap_node!(node, SimpleIdentifier, EscapedIdentifier) {
+        Some(RefNode::SimpleIdentifier(x)) => Some(x.nodes.0),
+        Some(RefNode::EscapedIdentifier(x)) => Some(x.nodes.0),
+        _ => None,
+    }
+}

--- a/testcases/syntaxrules/fail/implicit_case_default.sv
+++ b/testcases/syntaxrules/fail/implicit_case_default.sv
@@ -8,9 +8,9 @@ endmodule
 module M;
   always_comb begin
     y = 0;
-    case(x)
+    case (x)
       1: y = 1;
-      2: begin 
+      2: begin
         z = 1;
         w = 1;
       end
@@ -21,7 +21,7 @@ endmodule
 module M;
   always_comb begin
     a = 0;
-    case(x)
+    case (x)
       1: b = 0;
     endcase
   end

--- a/testcases/syntaxrules/fail/implicit_case_default.sv
+++ b/testcases/syntaxrules/fail/implicit_case_default.sv
@@ -1,0 +1,16 @@
+module M;
+  always_comb
+    case (x)
+      1: a = 0; // No implicit or explicit case default
+    endcase
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  always_comb begin
+    a = 0;
+
+    case(x)
+      1: b = 0;
+    endcase
+  end
+endmodule

--- a/testcases/syntaxrules/fail/implicit_case_default.sv
+++ b/testcases/syntaxrules/fail/implicit_case_default.sv
@@ -7,8 +7,20 @@ endmodule
 ////////////////////////////////////////////////////////////////////////////////
 module M;
   always_comb begin
+    y = 0;
+    case(x)
+      1: y = 1;
+      2: begin 
+        z = 1;
+        w = 1;
+      end
+    endcase
+  end
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  always_comb begin
     a = 0;
-
     case(x)
       1: b = 0;
     endcase

--- a/testcases/syntaxrules/pass/implicit_case_default.sv
+++ b/testcases/syntaxrules/pass/implicit_case_default.sv
@@ -7,6 +7,21 @@ module M;
 endmodule
 ////////////////////////////////////////////////////////////////////////////////
 module M;
+  always_comb begin
+    y = 0;
+    z = 0;
+    w = 0;
+    case(x)
+      1: y = 1;
+      2: begin 
+        z = 1;
+        w = 1;
+      end
+    endcase
+  end
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
   always_comb
     case(x)
       1: y = 1;

--- a/testcases/syntaxrules/pass/implicit_case_default.sv
+++ b/testcases/syntaxrules/pass/implicit_case_default.sv
@@ -1,0 +1,15 @@
+module M;
+  always_comb
+    y = 0;
+    case(x)
+      1: y = 1; // case default is implicit
+    endcase
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  always_comb
+    case(x)
+      1: y = 1;
+      default: y = 0;
+    endcase
+endmodule

--- a/testcases/syntaxrules/pass/implicit_case_default.sv
+++ b/testcases/syntaxrules/pass/implicit_case_default.sv
@@ -1,9 +1,10 @@
 module M;
-  always_comb
+  always_comb begin
     y = 0;
-    case(x)
+    case (x)
       1: y = 1; // case default is implicit
     endcase
+  end
 endmodule
 ////////////////////////////////////////////////////////////////////////////////
 module M;
@@ -11,9 +12,9 @@ module M;
     y = 0;
     z = 0;
     w = 0;
-    case(x)
+    case (x)
       1: y = 1;
-      2: begin 
+      2: begin
         z = 1;
         w = 1;
       end
@@ -23,8 +24,33 @@ endmodule
 ////////////////////////////////////////////////////////////////////////////////
 module M;
   always_comb
-    case(x)
+    case (x)
       1: y = 1;
       default: y = 0;
     endcase
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  always_comb
+    case (x)
+      1: p = 1;
+      2: q = 0;
+      default: begin
+        p = 0;
+        q = 0;
+      end
+    endcase
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  always_comb begin
+    p = 0;  // p -> implicit default
+    q = 0;  // q -> implicit default
+    case (x)
+      1: p = 1;
+      2: q = 1;
+      3: r = 1;
+      default: r = 1; // r -> explicit default
+    endcase
+  end
 endmodule


### PR DESCRIPTION
This pull request is a simple case implementation for implicit case default. It keeps track of implicitly defined variables in a vector and references it when it encounters it under the case statement. Passes if there is a default case defined.

### Relevant Issues
- closes dalance/svlint#268