### PR TITLE
New rule that ensures module/interface/package/program identifier matches the filename it's in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 /Cargo.lock
+.svlint.toml
+.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,3 +147,4 @@ under the Developer Certificate of Origin <https://developercertificate.org/>.
 - Taichi Ishitani (@taichi-ishitani)
 - Sosuke Hosokawa (@so298)
 - Jan Remes (@remes-codasip)
+- Shantanu Sinha (@ShantanuPSinha)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2193,8 +2193,12 @@ Encourages consistent file naming standards for packages and assists in searchin
 
 ### Pass Example (1 of 1)
 ```systemverilog
-interface syntaxrules_interface_identifier_matches_filename_pass_1of1;
+interface syntaxrules;
 endinterface
+
+// This testcase, when executed, is called from a file named "syntaxrules.interface_identifier_matches_filename.pass.1of1"
+// The rule matches all valid characters up until the first non-identifier (in this case, the period).
+// The file identifier to be matched in this case becomes "syntaxrules" which matches the interface identifier
 ```
 
 ### Fail Example (1 of 1)
@@ -2205,11 +2209,21 @@ endinterface
 
 ### Explanation
 
-Interface Identifier should have the same name as the file it's in.
+Interface identifier should have the same name as the file it's in.
 
-```interface Bar``` should be in ```some/path/to/Bar.sv```
+```interface foo;``` is allowed to live in any file of naming convention ```foo <Non-Identifier> <whatever else>```
 
-Note that as a result, only one interface can be declared per file.
+According to Clause 5.6 of IEEE 1800-2017:
+
+> A simple identifier shall consist of a sequence of letters, digits, dollar signs (`$`), and underscore (`_`) characters.
+
+Any symbol defined outside this exhaustive list is considered a non-identifier.
+
+The stopping point for string matching has to be a non-identifier character.
+
+For example, the interface declaration ```interface foo;``` is valid in filenames such as ```foo-Bar.sv```, ```foo.debug.sv```, and ```foo-final-version.sv```. Each of these filenames begins with the interface identifier ```foo``` and is immediately followed by a non-identifier character (```-```, ```.```, or another acceptable symbol), making them compliant. A filename like ```FooBar.sv``` is invalid for the ```interface Foo;``` declaration since it does not contain a non-identifier character following the interface name.
+
+Note that as a consequence, only one interface can be declared per file.
 
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -3687,8 +3701,12 @@ Encourages consistent file naming standards for packages and assists in searchin
 
 ### Pass Example (1 of 1)
 ```systemverilog
-module syntaxrules_module_identifier_matches_filename_pass_1of1;
-endmodule
+module syntaxrules;
+endmodule 
+
+// This testcase, when executed, is called from a file named "syntaxrules.module_identifier_matches_filename.pass.1of1"
+// The rule matches all valid characters up until the first non-identifier (in this case, the period).
+// The file identifier to be matched in this case becomes "syntaxrules" which matches the module identifier
 ```
 
 ### Fail Example (1 of 1)
@@ -3699,11 +3717,21 @@ endmodule
 
 ### Explanation
 
-Module Identifier should have the same name as the file it's in.
+Module identifier should have the same name as the file it's in.
 
-```module Bar``` should be in ```some/path/to/Bar.sv```
+```module foo;``` is allowed to live in any file of naming convention ```foo <Non-Identifier> <whatever else>```
 
-Note that as a result, only one module can be declared per file.
+According to Clause 5.6 of IEEE 1800-2017:
+
+> A simple identifier shall consist of a sequence of letters, digits, dollar signs (`$`), and underscore (`_`) characters.
+
+Any symbol defined outside this exhaustive list is considered a non-identifier.
+
+The stopping point for string matching has to be a non-identifier character.
+
+For example, the module declaration ```module foo;``` is valid in filenames such as ```foo-Bar.sv```, ```foo.debug.sv```, and ```foo-final-version.sv```. Each of these filenames begins with the module identifier ```foo``` and is immediately followed by a non-identifier character (```-```, ```.```, or another acceptable symbol), making them compliant. A filename like ```FooBar.sv``` is invalid for the ```module Foo;``` declaration since it does not contain a non-identifier character following the module name.
+
+Note that as a consequence, only one module can be declared per file.
 
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -4509,9 +4537,13 @@ Encourages consistent file naming standards for packages and assists in searchin
 
 ### Pass Example (1 of 1)
 ```systemverilog
-package syntaxrules_package_identifier_matches_filename_pass_1of1;
+package syntaxrules;
 endpackage
 
+
+// This testcase, when executed, is called from a file named "syntaxrules.package_identifier_matches_filename.pass.1of1"
+// The rule matches all valid characters up until the first non-identifier (in this case, the period).
+// The file identifier to be matched in this case becomes "syntaxrules" which matches the package identifier
 ```
 
 ### Fail Example (1 of 1)
@@ -4522,12 +4554,21 @@ endpackage
 
 ### Explanation
 
-Package Identifier should have the same name as the file it's in.
+Package identifier should have the same name as the file it's in.
 
-```package Bar``` should be in ```some/path/to/Bar.sv```
+```package foo;``` is allowed to live in any file of naming convention ```foo <Non-Identifier> <whatever else>```
 
+According to Clause 5.6 of IEEE 1800-2017:
 
-Note that as a result, only one package can be declared per file.
+> A simple identifier shall consist of a sequence of letters, digits, dollar signs (`$`), and underscore (`_`) characters.
+
+Any symbol defined outside this exhaustive list is considered a non-identifier.
+
+The stopping point for string matching has to be a non-identifier character.
+
+For example, the package declaration ```package foo;``` is valid in filenames such as ```foo-Bar.sv```, ```foo.debug.sv```, and ```foo-final-version.sv```. Each of these filenames begins with the package identifier ```foo``` and is immediately followed by a non-identifier character (```-```, ```.```, or another acceptable symbol), making them compliant. A filename like ```FooBar.sv``` is invalid for the ```package Foo;``` declaration since it does not contain a non-identifier character following the package name.
+
+Note that as a consequence, only one package can be declared per file.
 
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -5025,8 +5066,12 @@ Encourages consistent file naming standards for packages and assists in searchin
 
 ### Pass Example (1 of 1)
 ```systemverilog
-program syntaxrules_program_identifier_matches_filename_pass_1of1;
+program syntaxrules;
 endprogram
+
+// This testcase, when executed, is called from a file named "syntaxrules.program_identifier_matches_filename.pass.1of1"
+// The rule matches all valid characters up until the first non-identifier (in this case, the period).
+// The file identifier to be matched in this case becomes "syntaxrules" which matches the program identifier
 ```
 
 ### Fail Example (1 of 1)
@@ -5037,12 +5082,21 @@ endprogram
 
 ### Explanation
 
-Program Identifier should have the same name as the file it's in.
+Program identifier should have the same name as the file it's in.
 
-```program Bar``` should be in ```some/path/to/Bar.sv```
+```program foo;``` is allowed to live in any file of naming convention ```foo <Non-Identifier> <whatever else>```
 
+According to Clause 5.6 of IEEE 1800-2017:
 
-Note that as a result, only one program can be declared per file.
+> A simple identifier shall consist of a sequence of letters, digits, dollar signs (`$`), and underscore (`_`) characters.
+
+Any symbol defined outside this exhaustive list is considered a non-identifier.
+
+The stopping point for string matching has to be a non-identifier character.
+
+For example, the program declaration ```program foo;``` is valid in filenames such as ```foo-Bar.sv```, ```foo.debug.sv```, and ```foo-final-version.sv```. Each of these filenames begins with the program identifier ```foo``` and is immediately followed by a non-identifier character (```-```, ```.```, or another acceptable symbol), making them compliant. A filename like ```FooBar.sv``` is invalid for the ```program Foo;``` declaration since it does not contain a non-identifier character following the program name.
+
+Note that as a consequence, only one program can be declared per file.
 
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2181,6 +2181,39 @@ The most relevant clauses of IEEE1800-2017 are:
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
+## Syntax Rule: `interface_identifier_matches_filename`
+
+### Hint
+
+Ensure that the interface name matches the file name. Interface Bar should be in some/path/to/Bar.sv
+
+### Reason
+
+Encourages consistent file naming standards for packages and assists in searching for interfaces.
+
+### Pass Example (1 of 1)
+```systemverilog
+interface syntaxrules_interface_identifier_matches_filename_pass_1of1;
+endinterface
+```
+
+### Fail Example (1 of 1)
+```systemverilog
+interface Bar;
+endinterface
+```
+
+### Explanation
+
+Interface Identifier should have the same name as the file it's in.
+
+```interface Bar``` should be in ```some/path/to/Bar.sv```
+
+Note that as a result, only one interface can be declared per file.
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
 ## Syntax Rule: `interface_port_with_modport`
 
 ### Hint
@@ -3642,6 +3675,39 @@ The most relevant clauses of IEEE1800-2017 are:
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
+## Syntax Rule: `module_identifier_matches_filename`
+
+### Hint
+
+Ensure that the module name matches the file name. module Bar should be in some/path/to/Bar.sv
+
+### Reason
+
+Encourages consistent file naming standards for packages and assists in searching for modules.
+
+### Pass Example (1 of 1)
+```systemverilog
+module syntaxrules_module_identifier_matches_filename_pass_1of1;
+endmodule
+```
+
+### Fail Example (1 of 1)
+```systemverilog
+module Bar;
+endmodule
+```
+
+### Explanation
+
+Module Identifier should have the same name as the file it's in.
+
+```module Bar``` should be in ```some/path/to/Bar.sv```
+
+Note that as a result, only one module can be declared per file.
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
 ## Syntax Rule: `module_nonansi_forbidden`
 
 ### Hint
@@ -4431,6 +4497,41 @@ The most relevant clauses of IEEE1800-2017 are:
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
+## Syntax Rule: `package_identifier_matches_filename`
+
+### Hint
+
+Ensure that the package name name matches the file name. Package fooBar should be in some/path/to/fooBar.sv
+
+### Reason
+
+Encourages consistent file naming standards for packages and assists in searching for packages.
+
+### Pass Example (1 of 1)
+```systemverilog
+package syntaxrules_package_identifier_matches_filename_pass_1of1;
+endpackage
+
+```
+
+### Fail Example (1 of 1)
+```systemverilog
+package fooBar;
+endpackage
+```
+
+### Explanation
+
+Package Identifier should have the same name as the file it's in.
+
+```package Bar``` should be in ```some/path/to/Bar.sv```
+
+
+Note that as a result, only one package can be declared per file.
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
 ## Syntax Rule: `package_item_not_in_package`
 
 ### Hint
@@ -4908,6 +5009,40 @@ The most relevant clauses of IEEE1800-2017 are:
 - 10.6.1 The assign and deassign procedural statements
 - Annex C.4 Constructs identified for deprecation
 
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+## Syntax Rule: `program_identifier_matches_filename`
+
+### Hint
+
+Ensure that the program name matches the file name. program Bar should be in some/path/to/Bar.sv
+
+### Reason
+
+Encourages consistent file naming standards for packages and assists in searching for programs.
+
+### Pass Example (1 of 1)
+```systemverilog
+program syntaxrules_program_identifier_matches_filename_pass_1of1;
+endprogram
+```
+
+### Fail Example (1 of 1)
+```systemverilog
+program Bar;
+endprogram
+```
+
+### Explanation
+
+Program Identifier should have the same name as the file it's in.
+
+```program Bar``` should be in ```some/path/to/Bar.sv```
+
+
+Note that as a result, only one program can be declared per file.
 
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

--- a/build.rs
+++ b/build.rs
@@ -377,7 +377,7 @@ fn write_test_rs(
             for (t, testcase) in testcases.into_iter().enumerate().map(|(i, x)| (i + 1, x)) {
                 // Write subtest to its own file.
                 let subtest_path: std::path::PathBuf = Path::new(&out_dir)
-                    .join(format!("syntaxrules_{rulename}_{passfail}_{t}of{n_testcases}.sv"));
+                    .join(format!("syntaxrules.{rulename}.{passfail}.{t}of{n_testcases}.sv"));
                 let mut out_subtest = File::create(&subtest_path).unwrap();
                 for line in testcase {
                     let _ = writeln!(out_subtest, "{}", line);

--- a/build.rs
+++ b/build.rs
@@ -376,8 +376,8 @@ fn write_test_rs(
 
             for (t, testcase) in testcases.into_iter().enumerate().map(|(i, x)| (i + 1, x)) {
                 // Write subtest to its own file.
-                let subtest_path = Path::new(&out_dir)
-                    .join(format!("syntaxrules.{rulename}.{passfail}.{t}of{n_testcases}.sv"));
+                let subtest_path: std::path::PathBuf = Path::new(&out_dir)
+                    .join(format!("syntaxrules_{rulename}_{passfail}_{t}of{n_testcases}.sv"));
                 let mut out_subtest = File::create(&subtest_path).unwrap();
                 for line in testcase {
                     let _ = writeln!(out_subtest, "{}", line);

--- a/md/syntaxrules-explanation-interface_identifier_matches_filename.md
+++ b/md/syntaxrules-explanation-interface_identifier_matches_filename.md
@@ -1,5 +1,15 @@
-Interface Identifier should have the same name as the file it's in.
+Interface identifier should have the same name as the file it's in.
 
-```interface Bar``` should be in ```some/path/to/Bar.sv```
+```interface foo;``` is allowed to live in any file of naming convention ```foo <Non-Identifier> <whatever else>```
 
-Note that as a result, only one interface can be declared per file.
+According to Clause 5.6 of IEEE 1800-2017:
+
+> A simple identifier shall consist of a sequence of letters, digits, dollar signs (`$`), and underscore (`_`) characters.
+
+Any symbol defined outside this exhaustive list is considered a non-identifier.
+
+The stopping point for string matching has to be a non-identifier character.
+
+For example, the interface declaration ```interface foo;``` is valid in filenames such as ```foo-Bar.sv```, ```foo.debug.sv```, and ```foo-final-version.sv```. Each of these filenames begins with the interface identifier ```foo``` and is immediately followed by a non-identifier character (```-```, ```.```, or another acceptable symbol), making them compliant. A filename like ```FooBar.sv``` is invalid for the ```interface Foo;``` declaration since it does not contain a non-identifier character following the interface name.
+
+Note that as a consequence, only one interface can be declared per file.

--- a/md/syntaxrules-explanation-interface_identifier_matches_filename.md
+++ b/md/syntaxrules-explanation-interface_identifier_matches_filename.md
@@ -1,0 +1,5 @@
+Interface Identifier should have the same name as the file it's in.
+
+```interface Bar``` should be in ```some/path/to/Bar.sv```
+
+Note that as a result, only one interface can be declared per file.

--- a/md/syntaxrules-explanation-module_identifier_matches_filename.md
+++ b/md/syntaxrules-explanation-module_identifier_matches_filename.md
@@ -1,5 +1,15 @@
-Module Identifier should have the same name as the file it's in.
+Module identifier should have the same name as the file it's in.
 
-```module Bar``` should be in ```some/path/to/Bar.sv```
+```module foo;``` is allowed to live in any file of naming convention ```foo <Non-Identifier> <whatever else>```
 
-Note that as a result, only one module can be declared per file.
+According to Clause 5.6 of IEEE 1800-2017:
+
+> A simple identifier shall consist of a sequence of letters, digits, dollar signs (`$`), and underscore (`_`) characters.
+
+Any symbol defined outside this exhaustive list is considered a non-identifier.
+
+The stopping point for string matching has to be a non-identifier character.
+
+For example, the module declaration ```module foo;``` is valid in filenames such as ```foo-Bar.sv```, ```foo.debug.sv```, and ```foo-final-version.sv```. Each of these filenames begins with the module identifier ```foo``` and is immediately followed by a non-identifier character (```-```, ```.```, or another acceptable symbol), making them compliant. A filename like ```FooBar.sv``` is invalid for the ```module Foo;``` declaration since it does not contain a non-identifier character following the module name.
+
+Note that as a consequence, only one module can be declared per file.

--- a/md/syntaxrules-explanation-module_identifier_matches_filename.md
+++ b/md/syntaxrules-explanation-module_identifier_matches_filename.md
@@ -1,0 +1,5 @@
+Module Identifier should have the same name as the file it's in.
+
+```module Bar``` should be in ```some/path/to/Bar.sv```
+
+Note that as a result, only one module can be declared per file.

--- a/md/syntaxrules-explanation-package_identifier_matches_filename.md
+++ b/md/syntaxrules-explanation-package_identifier_matches_filename.md
@@ -1,0 +1,6 @@
+Package Identifier should have the same name as the file it's in.
+
+```package Bar``` should be in ```some/path/to/Bar.sv```
+
+
+Note that as a result, only one package can be declared per file.

--- a/md/syntaxrules-explanation-package_identifier_matches_filename.md
+++ b/md/syntaxrules-explanation-package_identifier_matches_filename.md
@@ -1,6 +1,15 @@
-Package Identifier should have the same name as the file it's in.
+Package identifier should have the same name as the file it's in.
 
-```package Bar``` should be in ```some/path/to/Bar.sv```
+```package foo;``` is allowed to live in any file of naming convention ```foo <Non-Identifier> <whatever else>```
 
+According to Clause 5.6 of IEEE 1800-2017:
 
-Note that as a result, only one package can be declared per file.
+> A simple identifier shall consist of a sequence of letters, digits, dollar signs (`$`), and underscore (`_`) characters.
+
+Any symbol defined outside this exhaustive list is considered a non-identifier.
+
+The stopping point for string matching has to be a non-identifier character.
+
+For example, the package declaration ```package foo;``` is valid in filenames such as ```foo-Bar.sv```, ```foo.debug.sv```, and ```foo-final-version.sv```. Each of these filenames begins with the package identifier ```foo``` and is immediately followed by a non-identifier character (```-```, ```.```, or another acceptable symbol), making them compliant. A filename like ```FooBar.sv``` is invalid for the ```package Foo;``` declaration since it does not contain a non-identifier character following the package name.
+
+Note that as a consequence, only one package can be declared per file.

--- a/md/syntaxrules-explanation-program_identifier_matches_filename.md
+++ b/md/syntaxrules-explanation-program_identifier_matches_filename.md
@@ -1,0 +1,6 @@
+Program Identifier should have the same name as the file it's in.
+
+```program Bar``` should be in ```some/path/to/Bar.sv```
+
+
+Note that as a result, only one program can be declared per file.

--- a/md/syntaxrules-explanation-program_identifier_matches_filename.md
+++ b/md/syntaxrules-explanation-program_identifier_matches_filename.md
@@ -1,6 +1,15 @@
-Program Identifier should have the same name as the file it's in.
+Program identifier should have the same name as the file it's in.
 
-```program Bar``` should be in ```some/path/to/Bar.sv```
+```program foo;``` is allowed to live in any file of naming convention ```foo <Non-Identifier> <whatever else>```
 
+According to Clause 5.6 of IEEE 1800-2017:
 
-Note that as a result, only one program can be declared per file.
+> A simple identifier shall consist of a sequence of letters, digits, dollar signs (`$`), and underscore (`_`) characters.
+
+Any symbol defined outside this exhaustive list is considered a non-identifier.
+
+The stopping point for string matching has to be a non-identifier character.
+
+For example, the program declaration ```program foo;``` is valid in filenames such as ```foo-Bar.sv```, ```foo.debug.sv```, and ```foo-final-version.sv```. Each of these filenames begins with the program identifier ```foo``` and is immediately followed by a non-identifier character (```-```, ```.```, or another acceptable symbol), making them compliant. A filename like ```FooBar.sv``` is invalid for the ```program Foo;``` declaration since it does not contain a non-identifier character following the program name.
+
+Note that as a consequence, only one program can be declared per file.

--- a/src/syntaxrules/interface_identifier_matches_filename.rs
+++ b/src/syntaxrules/interface_identifier_matches_filename.rs
@@ -44,10 +44,22 @@ impl SyntaxRule for InterfaceIdentifierMatchesFilename {
                 let interface_name = syntax_tree.get_str(id.unwrap()).unwrap();
         
                 let path = std::path::Path::new(path_str);
-                if let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) {
-                    if file_name.ends_with(".sv") {
-                        let file_ident = file_name.trim_end_matches(".sv");
-                        if interface_name == file_ident {
+                if let Some(file_name_os_str) = path.file_name() {
+                    if let Some(file_name) = file_name_os_str.to_str() {
+                        let mut identifier_end = 0;
+                        for (i, c) in file_name.char_indices() {
+                            if c.is_alphanumeric() || c == '_' || c == '$' {
+                                identifier_end = i + c.len_utf8();
+                            } else {
+                                // Stop at the first non-identifier character
+                                break;
+                            }
+                        }
+
+                        let file_ident = &file_name[..identifier_end];
+
+                        // Ignoring Case
+                        if file_ident.eq_ignore_ascii_case(interface_name) {
                             return SyntaxRuleResult::Pass;
                         }
                     }

--- a/src/syntaxrules/interface_identifier_matches_filename.rs
+++ b/src/syntaxrules/interface_identifier_matches_filename.rs
@@ -1,0 +1,76 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{unwrap_locate, NodeEvent, RefNode, SyntaxTree, unwrap_node, Locate};
+
+#[derive(Default)]
+pub struct InterfaceIdentifierMatchesFilename;
+impl SyntaxRule for InterfaceIdentifierMatchesFilename {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return SyntaxRuleResult::Pass;
+            }
+        };
+
+        match node {
+            RefNode::InterfaceIdentifier(x) => {
+                let path_str = if let Some(x) = unwrap_locate!(node.clone()) {
+                    if let Some((path, _)) = syntax_tree.get_origin(&x) {
+                        path
+                    } else {
+                        return SyntaxRuleResult::Fail;
+                    }
+                } else {
+                    return SyntaxRuleResult::Fail;
+                };
+        
+                let id: Option<&Locate> = match unwrap_node!(*x, SimpleIdentifier) {
+                    Some(RefNode::SimpleIdentifier(id_)) => {
+                        unwrap_locate!(id_)
+                    },
+                    _ => None,
+                };
+        
+                if id.is_none() {
+                    return SyntaxRuleResult::Fail;
+                }
+        
+                let interface_name = syntax_tree.get_str(id.unwrap()).unwrap();
+        
+                let path = std::path::Path::new(path_str);
+                if let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) {
+                    if file_name.ends_with(".sv") {
+                        let file_ident = file_name.trim_end_matches(".sv");
+                        if interface_name == file_ident {
+                            return SyntaxRuleResult::Pass;
+                        }
+                    }
+                }
+        
+                SyntaxRuleResult::Fail      
+            },
+
+            _ => SyntaxRuleResult::Pass,
+        }
+        
+    }
+
+    fn name(&self) -> String {
+        String::from("interface_identifier_matches_filename")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("Ensure that the interface name matches the file name. Interface Bar should be in some/path/to/Bar.sv")
+    }
+
+    fn reason(&self) -> String {
+        String::from("Encourages consistent file naming standards for packages and assists in searching for interfaces.")
+    }
+
+}

--- a/src/syntaxrules/module_identifier_matches_filename.rs
+++ b/src/syntaxrules/module_identifier_matches_filename.rs
@@ -41,7 +41,6 @@ impl SyntaxRule for ModuleIdentifierMatchesFilename {
                 let path = std::path::Path::new(&path_str);
                 if let Some(file_name_os_str) = path.file_name() {
                     if let Some(file_name) = file_name_os_str.to_str() {
-                        // Iterate over each character in the file name to find the first non-identifier character
                         let mut identifier_end = 0;
                         for (i, c) in file_name.char_indices() {
                             if c.is_alphanumeric() || c == '_' || c == '$' {
@@ -53,10 +52,6 @@ impl SyntaxRule for ModuleIdentifierMatchesFilename {
                         }
 
                         let file_ident = &file_name[..identifier_end];
-
-                        println !("\n\nPath: {:?}", path_str);
-
-                        println!("File: {}, Module: {}\n\n", file_ident, module_name);
 
                         // Ignoring Case
                         if file_ident.eq_ignore_ascii_case(module_name) {

--- a/src/syntaxrules/module_identifier_matches_filename.rs
+++ b/src/syntaxrules/module_identifier_matches_filename.rs
@@ -1,0 +1,67 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{unwrap_locate, NodeEvent, RefNode, SyntaxTree, unwrap_node};
+
+#[derive(Default)]
+pub struct ModuleIdentifierMatchesFilename;
+impl SyntaxRule for ModuleIdentifierMatchesFilename {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return SyntaxRuleResult::Pass;
+            }
+        };
+
+        match node {
+            RefNode::ModuleDeclaration(x) => {
+                let path_str = if let Some(x) = unwrap_locate!(node.clone()) {
+                    if let Some((path, _)) = syntax_tree.get_origin(&x) {
+                        path
+                    } else {
+                        return SyntaxRuleResult::Fail;
+                    }
+                } else {
+                    return SyntaxRuleResult::Fail;
+                };
+        
+                let module_name = if let Some(RefNode::ModuleIdentifier(module_ident)) = unwrap_node!(*x, ModuleIdentifier) {
+                    syntax_tree.get_str(module_ident).unwrap()
+                } else {
+                    return SyntaxRuleResult::Fail;
+                };
+        
+                // Use the extracted path_str and module_name to perform the file name check
+                let path = std::path::Path::new(&path_str);
+                if let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) {
+                    if file_name.ends_with(".sv") {
+                        let file_ident = file_name.trim_end_matches(".sv");
+                        if file_ident == module_name {
+                            return SyntaxRuleResult::Pass;
+                        }
+                    }
+                }
+                SyntaxRuleResult::Fail
+            }
+            _ => SyntaxRuleResult::Pass,
+        }   
+        
+    }
+
+    fn name(&self) -> String {
+        String::from("module_identifier_matches_filename")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("Ensure that the module name matches the file name. module Bar should be in some/path/to/Bar.sv")
+    }
+
+    fn reason(&self) -> String {
+        String::from("Encourages consistent file naming standards for packages and assists in searching for modules.")
+    }
+}

--- a/src/syntaxrules/package_identifier_matches_filename.rs
+++ b/src/syntaxrules/package_identifier_matches_filename.rs
@@ -1,0 +1,76 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{unwrap_locate, NodeEvent, RefNode, SyntaxTree, unwrap_node, Locate};
+
+#[derive(Default)]
+pub struct PackageIdentifierMatchesFilename;
+impl SyntaxRule for PackageIdentifierMatchesFilename {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return SyntaxRuleResult::Pass;
+            }
+        };
+
+        match node {
+            RefNode::PackageIdentifier(x) => {
+                let path_str = if let Some(x) = unwrap_locate!(node.clone()) {
+                    if let Some((path, _)) = syntax_tree.get_origin(&x) {
+                        path
+                    } else {
+                        return SyntaxRuleResult::Fail;
+                    }
+                } else {
+                    return SyntaxRuleResult::Fail;
+                };
+        
+                let id: Option<&Locate> = match unwrap_node!(*x, SimpleIdentifier) {
+                    Some(RefNode::SimpleIdentifier(id_)) => {
+                        unwrap_locate!(id_)
+                    },
+                    _ => None,
+                };
+        
+                if id.is_none() {
+                    return SyntaxRuleResult::Fail;
+                }
+        
+                let package_name = syntax_tree.get_str(id.unwrap()).unwrap();
+        
+                let path = std::path::Path::new(path_str);
+                if let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) {
+                    if file_name.ends_with(".sv") {
+                        let file_ident = file_name.trim_end_matches(".sv");
+                        if package_name == file_ident {
+                            return SyntaxRuleResult::Pass;
+                        }
+                    }
+                }
+                 
+                SyntaxRuleResult::Fail      
+            },
+
+            _ => SyntaxRuleResult::Pass,
+        }
+        
+    }
+
+    fn name(&self) -> String {
+        String::from("package_identifier_matches_filename")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("Ensure that the package name name matches the file name. Package fooBar should be in some/path/to/fooBar.sv")
+    }
+
+    fn reason(&self) -> String {
+        String::from("Encourages consistent file naming standards for packages and assists in searching for packages.")
+    }
+
+}

--- a/src/syntaxrules/package_identifier_matches_filename.rs
+++ b/src/syntaxrules/package_identifier_matches_filename.rs
@@ -44,10 +44,22 @@ impl SyntaxRule for PackageIdentifierMatchesFilename {
                 let package_name = syntax_tree.get_str(id.unwrap()).unwrap();
         
                 let path = std::path::Path::new(path_str);
-                if let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) {
-                    if file_name.ends_with(".sv") {
-                        let file_ident = file_name.trim_end_matches(".sv");
-                        if package_name == file_ident {
+                if let Some(file_name_os_str) = path.file_name() {
+                    if let Some(file_name) = file_name_os_str.to_str() {
+                        let mut identifier_end = 0;
+                        for (i, c) in file_name.char_indices() {
+                            if c.is_alphanumeric() || c == '_' || c == '$' {
+                                identifier_end = i + c.len_utf8();
+                            } else {
+                                // Stop at the first non-identifier character
+                                break;
+                            }
+                        }
+
+                        let file_ident = &file_name[..identifier_end];
+
+                        // Ignoring Case
+                        if file_ident.eq_ignore_ascii_case(package_name) {
                             return SyntaxRuleResult::Pass;
                         }
                     }

--- a/src/syntaxrules/program_identifier_matches_filename.rs
+++ b/src/syntaxrules/program_identifier_matches_filename.rs
@@ -44,10 +44,22 @@ impl SyntaxRule for ProgramIdentifierMatchesFilename {
                 let program_name = syntax_tree.get_str(id.unwrap()).unwrap();
         
                 let path = std::path::Path::new(path_str);
-                if let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) {
-                    if file_name.ends_with(".sv") {
-                        let file_ident = file_name.trim_end_matches(".sv");
-                        if program_name == file_ident {
+                if let Some(file_name_os_str) = path.file_name() {
+                    if let Some(file_name) = file_name_os_str.to_str() {
+                        let mut identifier_end = 0;
+                        for (i, c) in file_name.char_indices() {
+                            if c.is_alphanumeric() || c == '_' || c == '$' {
+                                identifier_end = i + c.len_utf8();
+                            } else {
+                                // Stop at the first non-identifier character
+                                break;
+                            }
+                        }
+
+                        let file_ident = &file_name[..identifier_end];
+
+                        // Ignoring Case
+                        if file_ident.eq_ignore_ascii_case(program_name) {
                             return SyntaxRuleResult::Pass;
                         }
                     }

--- a/src/syntaxrules/program_identifier_matches_filename.rs
+++ b/src/syntaxrules/program_identifier_matches_filename.rs
@@ -1,0 +1,76 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{unwrap_locate, NodeEvent, RefNode, SyntaxTree, unwrap_node, Locate};
+
+#[derive(Default)]
+pub struct ProgramIdentifierMatchesFilename;
+impl SyntaxRule for ProgramIdentifierMatchesFilename {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        let node = match event {
+            NodeEvent::Enter(x) => x,
+            NodeEvent::Leave(_) => {
+                return SyntaxRuleResult::Pass;
+            }
+        };
+
+        match node {
+            RefNode::ProgramIdentifier(x) => {
+                let path_str = if let Some(x) = unwrap_locate!(node.clone()) {
+                    if let Some((path, _)) = syntax_tree.get_origin(&x) {
+                        path
+                    } else {
+                        return SyntaxRuleResult::Fail;
+                    }
+                } else {
+                    return SyntaxRuleResult::Fail;
+                };
+        
+                let id: Option<&Locate> = match unwrap_node!(*x, SimpleIdentifier) {
+                    Some(RefNode::SimpleIdentifier(id_)) => {
+                        unwrap_locate!(id_)
+                    },
+                    _ => None,
+                };
+        
+                if id.is_none() {
+                    return SyntaxRuleResult::Fail;
+                }
+        
+                let program_name = syntax_tree.get_str(id.unwrap()).unwrap();
+        
+                let path = std::path::Path::new(path_str);
+                if let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) {
+                    if file_name.ends_with(".sv") {
+                        let file_ident = file_name.trim_end_matches(".sv");
+                        if program_name == file_ident {
+                            return SyntaxRuleResult::Pass;
+                        }
+                    }
+                }
+        
+                SyntaxRuleResult::Fail      
+            },
+
+            _ => SyntaxRuleResult::Pass,
+        }
+        
+    }
+
+    fn name(&self) -> String {
+        String::from("program_identifier_matches_filename")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("Ensure that the program name matches the file name. program Bar should be in some/path/to/Bar.sv")
+    }
+
+    fn reason(&self) -> String {
+        String::from("Encourages consistent file naming standards for packages and assists in searching for programs.")
+    }
+
+}

--- a/testcases/syntaxrules/fail/interface_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/fail/interface_identifier_matches_filename.sv
@@ -1,0 +1,2 @@
+interface Bar;
+endinterface

--- a/testcases/syntaxrules/fail/module_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/fail/module_identifier_matches_filename.sv
@@ -1,0 +1,2 @@
+module Bar;
+endmodule

--- a/testcases/syntaxrules/fail/package_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/fail/package_identifier_matches_filename.sv
@@ -1,0 +1,2 @@
+package fooBar;
+endpackage

--- a/testcases/syntaxrules/fail/program_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/fail/program_identifier_matches_filename.sv
@@ -1,0 +1,2 @@
+program Bar;
+endprogram

--- a/testcases/syntaxrules/pass/interface_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/interface_identifier_matches_filename.sv
@@ -1,0 +1,2 @@
+interface syntaxrules_interface_identifier_matches_filename_pass_1of1;
+endinterface

--- a/testcases/syntaxrules/pass/interface_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/interface_identifier_matches_filename.sv
@@ -1,2 +1,6 @@
 interface syntaxrules;
 endinterface
+
+// This testcase, when executed, is called from a file named "syntaxrules.interface_identifier_matches_filename.pass.1of1"
+// The rule matches all valid characters up until the first non-identifier (in this case, the period).
+// The file identifier to be matched in this case becomes "syntaxrules" which matches the interface identifier

--- a/testcases/syntaxrules/pass/interface_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/interface_identifier_matches_filename.sv
@@ -1,2 +1,2 @@
-interface syntaxrules_interface_identifier_matches_filename_pass_1of1;
+interface syntaxrules;
 endinterface

--- a/testcases/syntaxrules/pass/module_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/module_identifier_matches_filename.sv
@@ -1,2 +1,2 @@
-module syntaxrules_module_identifier_matches_filename_pass_1of1;
+module syntaxrules;
 endmodule

--- a/testcases/syntaxrules/pass/module_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/module_identifier_matches_filename.sv
@@ -1,0 +1,2 @@
+module syntaxrules_module_identifier_matches_filename_pass_1of1;
+endmodule

--- a/testcases/syntaxrules/pass/module_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/module_identifier_matches_filename.sv
@@ -1,2 +1,6 @@
 module syntaxrules;
-endmodule
+endmodule 
+
+// This testcase, when executed, is called from a file named "syntaxrules.module_identifier_matches_filename.pass.1of1"
+// The rule matches all valid characters up until the first non-identifier (in this case, the period).
+// The file identifier to be matched in this case becomes "syntaxrules" which matches the module identifier

--- a/testcases/syntaxrules/pass/package_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/package_identifier_matches_filename.sv
@@ -1,3 +1,3 @@
-package syntaxrules_package_identifier_matches_filename_pass_1of1;
+package syntaxrules;
 endpackage
 

--- a/testcases/syntaxrules/pass/package_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/package_identifier_matches_filename.sv
@@ -1,3 +1,7 @@
 package syntaxrules;
 endpackage
 
+
+// This testcase, when executed, is called from a file named "syntaxrules.package_identifier_matches_filename.pass.1of1"
+// The rule matches all valid characters up until the first non-identifier (in this case, the period).
+// The file identifier to be matched in this case becomes "syntaxrules" which matches the package identifier

--- a/testcases/syntaxrules/pass/package_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/package_identifier_matches_filename.sv
@@ -1,0 +1,3 @@
+package syntaxrules_package_identifier_matches_filename_pass_1of1;
+endpackage
+

--- a/testcases/syntaxrules/pass/program_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/program_identifier_matches_filename.sv
@@ -1,0 +1,2 @@
+program syntaxrules_program_identifier_matches_filename_pass_1of1;
+endprogram

--- a/testcases/syntaxrules/pass/program_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/program_identifier_matches_filename.sv
@@ -1,2 +1,2 @@
-program syntaxrules_program_identifier_matches_filename_pass_1of1;
+program syntaxrules;
 endprogram

--- a/testcases/syntaxrules/pass/program_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/program_identifier_matches_filename.sv
@@ -1,2 +1,6 @@
 program syntaxrules;
 endprogram
+
+// This testcase, when executed, is called from a file named "syntaxrules.program_identifier_matches_filename.pass.1of1"
+// The rule matches all valid characters up until the first non-identifier (in this case, the period).
+// The file identifier to be matched in this case becomes "syntaxrules" which matches the program identifier


### PR DESCRIPTION
Closes dalance/svlint#252

The pass testcase is slightly unintuitive in that the module name does not actually match the file it's currently in, but works due to how build.rs modifies the filenames for testing.