### PR TITLE
Remove clone call

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -227,7 +227,7 @@ impl Linter {
             NodeEvent::Enter(x) => x,
             NodeEvent::Leave(x) => x,
         };
-        let locate = if let Some(x) = unwrap_locate!(node.clone()) {
+        let locate = if let Some(x) = unwrap_locate!(node) {
             x
         } else {
             return vec![];


### PR DESCRIPTION
Remove clone call that is not needed. 

(Background: I have run svlint on a large code base. The total run time was 14 minutes. I tried profiling the code and noticed that the top 3 functions were memory allocations. I have not had the time to find out exactly where those memory allocations are coming from. This is my best shot at improving performance with the limited time that I have had.

For comparison the verible-verilog-lint runs in less than a second)