### PR TITLE
feat: add support for file encoding detection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,3 +150,4 @@ under the Developer Certificate of Origin <https://developercertificate.org/>.
 - Shantanu Sinha (@ShantanuPSinha)
 - Ronit Nallagatla (@ronitnallagatla)
 - Shreyas Chinnola (@ShreChinno)
+- An Yudong (@iMMIQ)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ sv-parser               = "0.13.3"
 term                    = "1.0"
 toml                    = "0.8"
 sv-filelist-parser      = "0.1.3"
+chardetng               = "0.1.17"
+encoding_rs             = "0.8.34"
 
 [build-dependencies]
 regex   = "1"


### PR DESCRIPTION
- Add chardetng and encoding_rs dependencies in Cargo.toml to detect and decode non-UTF-8 files.
- Update file reading logic in main.rs to read bytes, detect encoding, and decode file contents.
- Introduce lint_gbk_encoded_verilog test case to verify processing of GBK-encoded Verilog files.