### PR TITLE
feat: add `style_keyword_1spaceornewline` rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,3 +151,4 @@ under the Developer Certificate of Origin <https://developercertificate.org/>.
 - Ronit Nallagatla (@ronitnallagatla)
 - Shreyas Chinnola (@ShreChinno)
 - An Yudong (@iMMIQ)
+- Bryce Berger (@bryceberger)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -9541,6 +9541,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
@@ -9620,6 +9621,7 @@ See also:
 - **style_keyword_0or1space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
@@ -9689,6 +9691,7 @@ See also:
 - **style_keyword_0or1space** - Suggested companion rule.
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
@@ -9924,9 +9927,96 @@ See also:
 - **style_keyword_0or1space** - Suggested companion rule.
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
+- **style_keyword_maybelabel** - Suggested companion rule.
+- **style_keyword_new** - Suggested companion rule.
+- **style_keyword_newline** - Suggested companion rule.
+
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+## Syntax Rule: `style_keyword_1spaceornewline`
+
+### Hint
+
+Follow keyword with a newline or exactly 1 space.
+
+### Reason
+
+Consistent use of whitespace enhances readability by reducing visual noise.
+
+### Pass Example (1 of 3)
+```systemverilog
+module M();
+  always_comb
+    case (a) matches
+      tagged Jmp .j: b = 1;
+    endcase
+endmodule
+```
+
+### Pass Example (2 of 3)
+```systemverilog
+module M();
+  always_comb
+    if (a matches tagged Jmp .j)
+      b = 1;
+endmodule
+```
+
+### Pass Example (3 of 3)
+```systemverilog
+module M();
+  always_comb
+    case (a) matches // with a comment
+      tagged Jmp .j: b = 1;
+    endcase
+endmodule
+```
+
+### Fail Example (1 of 2)
+```systemverilog
+module M();
+  always_comb
+    if (a matches  tagged Jmp .j)
+      b = 1;
+endmodule
+```
+
+### Fail Example (2 of 2)
+```systemverilog
+module M();
+  always_comb
+    case (a) matches  // comment with two spaces
+      tagged Jmp .j: b = 1;
+    endcase
+endmodule
+```
+
+### Explanation
+
+This rule checks the whitespace immediately following the `matches` keyword.
+The `matches` keyword can be used inside the condition of an if statement,
+in which case there should be one space between the keyword and the following
+symbol, i.e. `matches (tagged ...)`.
+The `matches` keyword can also be used as part of a case statement, in which
+case there should be a newline between the keyword and the following identifier,
+i.e. `case (a) matches\ntagged ...:`
+
+See also:
+- **style_keyword_0or1space** - Suggested companion rule.
+- **style_keyword_0space** - Suggested companion rule.
+- **style_keyword_1or2space** - Suggested companion rule.
+- **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
+- **style_keyword_construct** - Suggested companion rule.
+- **style_keyword_datatype** - Potential companion rule.
+- **style_keyword_end** - Suggested companion rule.
+- **style_keyword_indent** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
 - **style_keyword_new** - Suggested companion rule.
 - **style_keyword_newline** - Suggested companion rule.
@@ -10024,6 +10114,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
@@ -10109,6 +10200,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
@@ -10200,6 +10292,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
@@ -10300,6 +10393,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
@@ -10396,6 +10490,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
@@ -10469,6 +10564,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
@@ -12934,6 +13030,7 @@ syntaxrules.style_keyword_0or1space = true
 syntaxrules.style_keyword_0space = true
 syntaxrules.style_keyword_1or2space = true
 syntaxrules.style_keyword_1space = true
+syntaxrules.style_keyword_1spaceornewline = true
 syntaxrules.style_keyword_construct = true
 syntaxrules.style_keyword_datatype = false # Overly restrictive.
 syntaxrules.style_keyword_end = true

--- a/md/ruleset-style.md
+++ b/md/ruleset-style.md
@@ -227,6 +227,7 @@ syntaxrules.style_keyword_0or1space = true
 syntaxrules.style_keyword_0space = true
 syntaxrules.style_keyword_1or2space = true
 syntaxrules.style_keyword_1space = true
+syntaxrules.style_keyword_1spaceornewline = true
 syntaxrules.style_keyword_construct = true
 syntaxrules.style_keyword_datatype = false # Overly restrictive.
 syntaxrules.style_keyword_end = true

--- a/md/syntaxrules-explanation-style_keyword_0or1space.md
+++ b/md/syntaxrules-explanation-style_keyword_0or1space.md
@@ -10,6 +10,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_keyword_0space.md
+++ b/md/syntaxrules-explanation-style_keyword_0space.md
@@ -18,6 +18,7 @@ See also:
 - **style_keyword_0or1space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_keyword_1or2space.md
+++ b/md/syntaxrules-explanation-style_keyword_1or2space.md
@@ -21,6 +21,7 @@ See also:
 - **style_keyword_0or1space** - Suggested companion rule.
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_keyword_1space.md
+++ b/md/syntaxrules-explanation-style_keyword_1space.md
@@ -184,6 +184,7 @@ See also:
 - **style_keyword_0or1space** - Suggested companion rule.
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_keyword_1spaceornewline.md
+++ b/md/syntaxrules-explanation-style_keyword_1spaceornewline.md
@@ -1,25 +1,12 @@
-This rule checks the whitespace immediately following these keywords:
-, `endcase`
-, `endgenerate`
-, `endspecify`
-, `endtable`
-, `specify`
-, and `table`.
-These keywords are used to delimit code blocks and should always be followed by
-a newline or exactly 1 space then a comment, e.g:
-```systemverilog
-case (FOO)
-  ...
-endcase // Followed by a comment.
-
-// Followed by a newline.
-case (FOO)
-  ...
-endcase
-```
+This rule checks the whitespace immediately following the `matches` keyword.
+The `matches` keyword can be used inside the condition of an if statement,
+in which case there should be one space between the keyword and the following
+symbol, i.e. `matches (tagged ...)`.
+The `matches` keyword can also be used as part of a case statement, in which
+case there should be a newline between the keyword and the following identifier,
+i.e. `case (a) matches\ntagged ...:`
 
 See also:
-- **style_keyword_indent** - Suggested companion rule.
 - **style_keyword_0or1space** - Suggested companion rule.
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
@@ -28,5 +15,7 @@ See also:
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
+- **style_keyword_indent** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.
 - **style_keyword_new** - Suggested companion rule.
+- **style_keyword_newline** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_keyword_construct.md
+++ b/md/syntaxrules-explanation-style_keyword_construct.md
@@ -40,6 +40,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_keyword_datatype.md
+++ b/md/syntaxrules-explanation-style_keyword_datatype.md
@@ -37,6 +37,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_end** - Suggested companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_keyword_end.md
+++ b/md/syntaxrules-explanation-style_keyword_end.md
@@ -30,6 +30,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_maybelabel** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_keyword_maybelabel.md
+++ b/md/syntaxrules-explanation-style_keyword_maybelabel.md
@@ -45,6 +45,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.

--- a/md/syntaxrules-explanation-style_keyword_new.md
+++ b/md/syntaxrules-explanation-style_keyword_new.md
@@ -8,6 +8,7 @@ See also:
 - **style_keyword_0space** - Suggested companion rule.
 - **style_keyword_1or2space** - Suggested companion rule.
 - **style_keyword_1space** - Suggested companion rule.
+- **style_keyword_1spaceornewline** - Suggested companion rule.
 - **style_keyword_construct** - Suggested companion rule.
 - **style_keyword_datatype** - Potential companion rule.
 - **style_keyword_end** - Suggested companion rule.

--- a/rulesets/style.toml
+++ b/rulesets/style.toml
@@ -20,6 +20,7 @@ syntaxrules.style_keyword_0or1space = true
 syntaxrules.style_keyword_0space = true
 syntaxrules.style_keyword_1or2space = true
 syntaxrules.style_keyword_1space = true
+syntaxrules.style_keyword_1spaceornewline = true
 syntaxrules.style_keyword_construct = true
 syntaxrules.style_keyword_datatype = false # Overly restrictive.
 syntaxrules.style_keyword_end = true

--- a/src/syntaxrules/style_keyword_1space.rs
+++ b/src/syntaxrules/style_keyword_1space.rs
@@ -106,7 +106,6 @@ impl SyntaxRule for StyleKeyword1Space {
                 , "local"
                 , "localparam"
                 , "macromodule"
-                , "matches"
                 , "medium"
                 , "modport"
                 , "module"

--- a/src/syntaxrules/style_keyword_1spaceornewline.rs
+++ b/src/syntaxrules/style_keyword_1spaceornewline.rs
@@ -1,0 +1,64 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use regex::Regex;
+use sv_parser::{NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct StyleKeyword1SpaceOrNewline {
+    re_split: Option<Regex>,
+    re_kw: Option<Regex>,
+    re_succ: Option<Regex>,
+}
+
+impl SyntaxRule for StyleKeyword1SpaceOrNewline {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _config: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        let re_split = &*self.re_split.get_or_insert_with(|| {
+            Regex::new(r"(?P<kw>[\\$'BXZa-z_01]+)(?P<succ>(?s:.)*)").unwrap()
+        });
+        let re_kw = &*self.re_kw.get_or_insert_with(|| {
+            let keywords = [
+                "matches", // {{{
+            ]
+            .join("|"); // }}}
+            Regex::new(format!("^({})$", keywords).as_str()).unwrap()
+        });
+        let re_succ = &*self
+            .re_succ
+            .get_or_insert_with(|| Regex::new(r"^([\n\v\f\r]| /| [^ ]?$)").unwrap());
+
+        match event {
+            NodeEvent::Enter(RefNode::Keyword(x)) => {
+                let t = syntax_tree.get_str(*x).unwrap();
+                let caps = re_split.captures(t).unwrap();
+
+                if re_kw.is_match(&caps[1]) {
+                    if re_succ.is_match(&caps[2]) {
+                        SyntaxRuleResult::Pass
+                    } else {
+                        SyntaxRuleResult::Fail
+                    }
+                } else {
+                    SyntaxRuleResult::Pass
+                }
+            }
+            _ => SyntaxRuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("style_keyword_1spaceornewline")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("Follow keyword with a newline or exactly 1 space.")
+    }
+
+    fn reason(&self) -> String {
+        String::from("Consistent use of whitespace enhances readability by reducing visual noise.")
+    }
+}

--- a/testcases/syntaxrules/fail/style_keyword_1spaceornewline.sv
+++ b/testcases/syntaxrules/fail/style_keyword_1spaceornewline.sv
@@ -1,0 +1,12 @@
+module M();
+  always_comb
+    if (a matches  tagged Jmp .j)
+      b = 1;
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M();
+  always_comb
+    case (a) matches  // comment with two spaces
+      tagged Jmp .j: b = 1;
+    endcase
+endmodule

--- a/testcases/syntaxrules/pass/style_keyword_1spaceornewline.sv
+++ b/testcases/syntaxrules/pass/style_keyword_1spaceornewline.sv
@@ -1,0 +1,19 @@
+module M();
+  always_comb
+    case (a) matches
+      tagged Jmp .j: b = 1;
+    endcase
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M();
+  always_comb
+    if (a matches tagged Jmp .j)
+      b = 1;
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M();
+  always_comb
+    case (a) matches // with a comment
+      tagged Jmp .j: b = 1;
+    endcase
+endmodule


### PR DESCRIPTION
Closes #296

As mentioned in the linked issue, the `matches` keyword has two uses. In `if (a matches ...)`, it wants to have exactly one space. In `case (a) matches ...`, it wants a newline (or a space then comment). This PR adds a rule to handle these cases.