### PR TITLE
bugfix: module_identifier_matches_filename not escaping white-space

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ under the Developer Certificate of Origin <https://developercertificate.org/>.
 - Taichi Ishitani (@taichi-ishitani)
 - Sosuke Hosokawa (@so298)
 - Jan Remes (@remes-codasip)
-- Shantanu Sinha (@ShantanuPSinha)
+- Shantanu Sinha (@5han7anu-S)
 - Ronit Nallagatla (@ronitnallagatla)
 - Shreyas Chinnola (@ShreChinno)
 - An Yudong (@iMMIQ)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -3864,8 +3864,13 @@ Encourages consistent file naming standards for packages and assists in searchin
 
 ### Pass Example (1 of 1)
 ```systemverilog
-module syntaxrules;
+module syntaxrules();
 endmodule 
+
+
+// Allowing Whitespace in Module Names
+module syntaxrules ();
+endmodule
 
 // This testcase, when executed, is called from a file named "syntaxrules.module_identifier_matches_filename.pass.1of1"
 // The rule matches all valid characters up until the first non-identifier (in this case, the period).

--- a/src/syntaxrules/module_identifier_matches_filename.rs
+++ b/src/syntaxrules/module_identifier_matches_filename.rs
@@ -39,6 +39,7 @@ impl SyntaxRule for ModuleIdentifierMatchesFilename {
         
 
                 let path = std::path::Path::new(&path_str);
+
                 if let Some(file_name_os_str) = path.file_name() {
                     if let Some(file_name) = file_name_os_str.to_str() {
                         let mut identifier_end = 0;
@@ -46,15 +47,13 @@ impl SyntaxRule for ModuleIdentifierMatchesFilename {
                             if c.is_alphanumeric() || c == '_' || c == '$' {
                                 identifier_end = i + c.len_utf8();
                             } else {
-                                // Stop at the first non-identifier character
                                 break;
                             }
                         }
 
                         let file_ident = &file_name[..identifier_end];
 
-                        // Ignoring Case
-                        if file_ident.eq_ignore_ascii_case(module_name) {
+                        if file_ident.trim().eq_ignore_ascii_case(module_name.trim()) {
                             return SyntaxRuleResult::Pass;
                         }
                     }

--- a/testcases/syntaxrules/pass/module_identifier_matches_filename.sv
+++ b/testcases/syntaxrules/pass/module_identifier_matches_filename.sv
@@ -1,5 +1,10 @@
-module syntaxrules;
+module syntaxrules();
 endmodule 
+
+
+// Allowing Whitespace in Module Names
+module syntaxrules ();
+endmodule
 
 // This testcase, when executed, is called from a file named "syntaxrules.module_identifier_matches_filename.pass.1of1"
 // The rule matches all valid characters up until the first non-identifier (in this case, the period).


### PR DESCRIPTION
Closes #293

Simple fix in https://github.com/dalance/svlint/blob/c0ff9784a93348453872a0ab59627681d8c0de91/src/syntaxrules/module_identifier_matches_filename.rs#L57  

Trim the line to ignore white-space before checking equality. 

Modified my username in Contributing and generated Docs