### PR TITLE
Add rule to prevent mixing operators with confusing precedence

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1377,6 +1377,90 @@ The most relevant clauses of IEEE1800-2017 are:
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
+## Syntax Rule: `explicit_brackets_for_confusing_precedence`
+
+### Hint
+
+Add brackets to avoid ungrouped mix of comparison and bitwise operators.
+
+### Reason
+
+Avoids mistakes from assuming intuitive operator precedence.
+
+### Pass Example (1 of 2)
+```systemverilog
+module M;
+  logic a;
+  logic b;
+  logic c;
+  assign c = a == (b & 1);
+endmodule
+```
+
+### Pass Example (2 of 2)
+```systemverilog
+module M;
+  logic a;
+  logic b;
+  logic c;
+  assign c = a > b || a < b;
+endmodule
+```
+
+### Fail Example (1 of 2)
+```systemverilog
+module M;
+  logic a;
+  logic b;
+  logic c;
+  assign c = a == b & 1;
+endmodule
+```
+
+### Fail Example (2 of 2)
+```systemverilog
+module M;
+  logic a;
+  logic b;
+  logic c;
+  assign c = a > b | a < b;
+endmodule
+```
+
+### Explanation
+
+In SystemVerilog, like C, bitwise binary operators `&`, `|`, `^` and
+`~^`/`^~` (XNOR) have *lower* precedence than the comparison operators
+`>=`, `>`, `<`, `<=`, `==`, `!=`, `===`, `!==`, `==?` and `!=?`.
+This leads to surprising behaviour in code like this:
+
+```systemverilog
+logic [7:0] x;
+logic y;
+assign y = x & 8'h0F == '0;
+```
+
+The intention here was `(x & 8'h0F) == '0` but SystemVerilog will
+calculate `x & (8'h0F == '0)` which is always `1'b0`.
+
+In modern languages like Go, Rust, and Swift, bitwise operators have
+*higher* precedence than comparison operators.
+
+This rule forbids unbracketed expressions containing a mix of comparison
+and bitwise operators.
+Instead you can explicitly add brackets:
+
+```systemverilog
+assign y = (x & 8'h0F) == '0;
+```
+
+The most relevant clauses of IEEE1800-2017 are:
+- 11.3.2 Operator Precedence
+
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
 ## Syntax Rule: `explicit_case_default`
 
 ### Hint

--- a/md/syntaxrules-explanation-explicit_brackets_for_confusing_precedence.md
+++ b/md/syntaxrules-explanation-explicit_brackets_for_confusing_precedence.md
@@ -1,0 +1,27 @@
+In SystemVerilog, like C, bitwise binary operators `&`, `|`, `^` and
+`~^`/`^~` (XNOR) have *lower* precedence than the comparison operators
+`>=`, `>`, `<`, `<=`, `==`, `!=`, `===`, `!==`, `==?` and `!=?`.
+This leads to surprising behaviour in code like this:
+
+```systemverilog
+logic [7:0] x;
+logic y;
+assign y = x & 8'h0F == '0;
+```
+
+The intention here was `(x & 8'h0F) == '0` but SystemVerilog will
+calculate `x & (8'h0F == '0)` which is always `1'b0`.
+
+In modern languages like Go, Rust, and Swift, bitwise operators have
+*higher* precedence than comparison operators.
+
+This rule forbids unbracketed expressions containing a mix of comparison
+and bitwise operators.
+Instead you can explicitly add brackets:
+
+```systemverilog
+assign y = (x & 8'h0F) == '0;
+```
+
+The most relevant clauses of IEEE1800-2017 are:
+- 11.3.2 Operator Precedence

--- a/src/syntaxrules/explicit_brackets_for_confusing_precedence.rs
+++ b/src/syntaxrules/explicit_brackets_for_confusing_precedence.rs
@@ -1,0 +1,86 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{Expression, ExpressionBinary, NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct ExplicitBracketsForConfusingPrecedence;
+
+/// Recursively determine if a binary expression contains comparison (== etc.)
+/// and bitwise (& etc.) operators. This does NOT recurse into bracketed
+/// expressions.
+fn find_binary_operators(
+    syntax_tree: &SyntaxTree,
+    exp_bin: &ExpressionBinary,
+    has_comparison_op: &mut bool,
+    has_bitwise_op: &mut bool,
+) {
+    // Stop recursing if we've found both already.
+    if *has_comparison_op && *has_bitwise_op {
+        return;
+    }
+
+    let bin_op = &exp_bin.nodes.1;
+    let children = [&exp_bin.nodes.0, &exp_bin.nodes.3];
+
+    let bin_op_loc = &bin_op.nodes.0.nodes.0;
+    let bin_op_str = syntax_tree.get_str(bin_op_loc).unwrap();
+
+    match bin_op_str {
+        ">=" | ">" | "<" | "<=" | "==" | "!=" | "===" | "!==" | "==?" | "!=?" => {
+            *has_comparison_op = true
+        }
+        "&" | "|" | "^" | "^~" | "~^" => *has_bitwise_op = true,
+        _ => {}
+    }
+
+    for child in children {
+        match child {
+            Expression::Binary(bin) => {
+                find_binary_operators(syntax_tree, bin, has_comparison_op, has_bitwise_op);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl SyntaxRule for ExplicitBracketsForConfusingPrecedence {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        match event {
+            NodeEvent::Enter(RefNode::ExpressionBinary(exp_bin)) => {
+                let mut has_comparison_op = false;
+                let mut has_bitwise_op = false;
+
+                find_binary_operators(
+                    syntax_tree,
+                    exp_bin,
+                    &mut has_comparison_op,
+                    &mut has_bitwise_op,
+                );
+
+                if has_comparison_op && has_bitwise_op {
+                    SyntaxRuleResult::Fail
+                } else {
+                    SyntaxRuleResult::Pass
+                }
+            }
+            _ => SyntaxRuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("explicit_brackets_for_confusing_precedence")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("Add brackets to avoid ungrouped mix of comparison and bitwise operators.")
+    }
+
+    fn reason(&self) -> String {
+        String::from("Avoids mistakes from assuming intuitive operator precedence.")
+    }
+}

--- a/testcases/syntaxrules/fail/explicit_brackets_for_confusing_precedence.sv
+++ b/testcases/syntaxrules/fail/explicit_brackets_for_confusing_precedence.sv
@@ -1,0 +1,13 @@
+module M;
+  logic a;
+  logic b;
+  logic c;
+  assign c = a == b & 1;
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  logic a;
+  logic b;
+  logic c;
+  assign c = a > b | a < b;
+endmodule

--- a/testcases/syntaxrules/pass/explicit_brackets_for_confusing_precedence.sv
+++ b/testcases/syntaxrules/pass/explicit_brackets_for_confusing_precedence.sv
@@ -1,0 +1,13 @@
+module M;
+  logic a;
+  logic b;
+  logic c;
+  assign c = a == (b & 1);
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  logic a;
+  logic b;
+  logic c;
+  assign c = a > b || a < b;
+endmodule


### PR DESCRIPTION
This corresponds to similar warnings that GCC/Clang will give you (with -Wall) for mixing comparison and bitwise operators without brackets (because C has the same error-prone operator precedence).

Fixes #299 