### PR TITLE
Add missing error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -353,11 +353,17 @@ fn print_parser_error(
         SvParserError::Preprocess(Some((path, pos))) => {
             printer.print_preprocess_error(&path, pos, oneline)?;
         }
-        SvParserError::Include { source: x } => {
-            if let SvParserError::File { path: x, .. } = *x {
-                printer.print_error(&format!("failed to include '{}'", x.to_string_lossy()))?;
+        SvParserError::Include { source } => match *source {
+            SvParserError::File { source: _, path } => {
+                printer.print_error(&format!("failed to include '{}'", path.display()))?;
             }
-        }
+            SvParserError::DefineNotFound(define) => {
+                printer.print_error(&format!("definition not found for '{}'", define))?;
+            }
+            _ => {
+                printer.print_error(&format!("{}", source))?;
+            }
+        },
         SvParserError::ReadUtf8(path) => {
             printer.print_error(&format!("file '{}' is not valid UTF-8", path.display()))?;
         }


### PR DESCRIPTION
If a definition was not found inside an included file then the error would be `Include { source: DefineNotFound("FOO") }` which would previously not print a message at all. This prints a specific message and adds a catch all for other cases.

This should probably be a recursive function that builds a series of "in file included from..." messages that you see from C compilers, but that is a bigger change and this at least avoids having no error message at all.