### PR TITLE
Silence warnings about unexpected tarpaulin config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ walkdir = "2"
 
 #[patch.crates-io]
 #sv-parser = {path = "../sv-parser/sv-parser"}
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }


### PR DESCRIPTION
Rust now checks for unexpected `cfg` values (to detect typos) so it gives a load of warnings about `cfg(tarpaulin)`. This tells Rust to expect `cfg(tarpaulin)` so those warnings are silenced.